### PR TITLE
fix type inference bug

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -23,7 +23,7 @@ DistributedOperations = "1"
 JetPack = "1"
 Jets = "1"
 SpecialFunctions = "0.10"
-WaveFD = "0.1"
+WaveFD = "0.2"
 
 [extras]
 FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"

--- a/src/ginsu.jl
+++ b/src/ginsu.jl
@@ -256,14 +256,24 @@ Get a view of the Ginsu'd subset `mg` corresponding to its interior region which
 excludes the sponge.
 """
 function interior(ginsu::Ginsu{N}, prop_ginsu::AbstractArray{T,N}) where {T,N}
+    rng = interior(ginsu)
+    view(prop_ginsu, rng...)
+end
+
+"""
+    I = interior(ginsu)
+
+Get the index range corresponding to the interior region which excludes
+the sponge.
+"""
+function interior(ginsu::Ginsu{N}) where {N}
     AI = _op(ginsu, extend=false, interior=true)
     AE = _op(ginsu, extend=false, interior=false)
-    rng = ntuple(i->begin
+    ntuple(i->begin
             strt = state(AI).pad[i][1] - state(AE).pad[i][1] + 1
             stop = strt + length(state(AI).pad[i]) - 1
             strt:stop
-        end, N)::NTuple{N,UnitRange{Int}}
-    view(prop_ginsu, rng...)
+        end, Val{N}())
 end
 
 Base.size(gn::Ginsu, i::Int; interior=false) = length(state(_op(gn; interior=interior)).pad[i])

--- a/src/jop_prop2DAcoVTIDenQ_DEO2_FDTD.jl
+++ b/src/jop_prop2DAcoVTIDenQ_DEO2_FDTD.jl
@@ -56,10 +56,10 @@ function JetProp2DAcoVTIDenQ_DEO2_FDTD(;
     local active_wavefields, modeltype
     if "v" ∈ active_modelset_keys && "b" ∉ active_modelset_keys && "ϵ" ∈ active_modelset_keys && "η" ∈ active_modelset_keys
         active_wavefields = ["pold","mold","pspace","mspace"]
-        modeltype = WaveFD.Prop2DAcoVTIDenQ_DEO2_FDTD_Model_VEA
+        modeltype = WaveFD.Prop2DAcoVTIDenQ_DEO2_FDTD_Model_VEA()
     elseif "v" ∈ active_modelset_keys && "b" ∉ active_modelset_keys && "ϵ" ∉ active_modelset_keys && "η" ∉ active_modelset_keys
         active_wavefields = ["pspace","mspace"]
-        modeltype = WaveFD.Prop2DAcoVTIDenQ_DEO2_FDTD_Model_V
+        modeltype = WaveFD.Prop2DAcoVTIDenQ_DEO2_FDTD_Model_V()
     else
         error("unsupported model-space")
     end
@@ -430,6 +430,8 @@ function JopProp2DAcoVTIDenQ_DEO2_FDTD_nonlinearforward!(d::AbstractArray, m::Ab
     end
     model_ginsu["f"] .= kwargs[:f]
 
+    ginsu_interior_range = interior(kwargs[:ginsu])
+
     # we need to serialize "pold" for the data but, not (necessarily) for the linearization
     active_wavefields = "pold" ∈ kwargs[:active_wavefields] ? kwargs[:active_wavefields] : [kwargs[:active_wavefields]; "pold"]
 
@@ -447,12 +449,13 @@ function JopProp2DAcoVTIDenQ_DEO2_FDTD_nonlinearforward!(d::AbstractArray, m::Ab
     end
     blks_sou = WaveFD.source_blocking(nz_ginsu, nx_ginsu, kwargs[:nbz_inject], kwargs[:nbx_inject], iz_sou, ix_sou, c_sou)
 
-    c_sou_scaled = deepcopy(c_sou)
+    c_sou_scaled = Array{Array{Float32,2},1}(undef, length(c_sou))
     for i = 1:length(c_sou_scaled)
+        c_sou_scaled[i] = similar(c_sou[i])
         for ix = 1:size(c_sou_scaled[i], 2), iz = 1:size(c_sou_scaled[i], 1)
             jz = iz_sou[i][iz]
             jx = ix_sou[i][ix]
-            c_sou_scaled[i][iz,ix] *= kwargs[:dtmod]^2 * model_ginsu["v"][jz,jx]^2 / model_ginsu["b"][jz,jx]
+            c_sou_scaled[i][iz,ix] = c_sou[i][iz,ix] * kwargs[:dtmod]^2 * model_ginsu["v"][jz,jx]^2 / model_ginsu["b"][jz,jx]
         end
     end
     blks_sou_scaled = WaveFD.source_blocking(nz_ginsu, nx_ginsu, kwargs[:nbz_inject], kwargs[:nbx_inject], iz_sou, ix_sou, c_sou_scaled)
@@ -517,8 +520,13 @@ function JopProp2DAcoVTIDenQ_DEO2_FDTD_nonlinearforward!(d::AbstractArray, m::Ab
 
             if kwargs[:srcfieldfile] != ""
                 cumtime_io += @elapsed for active_wavefield in active_wavefields
-                    WaveFD.compressedwrite(iofield[active_wavefield], kwargs[:compressor][active_wavefield], div(it-1,itskip)+1,
-                        kwargs[:isinterior] ? interior(kwargs[:ginsu], wavefields[active_wavefield]) : wavefields[active_wavefield])
+                    if kwargs[:isinterior]
+                        WaveFD.compressedwrite(iofield[active_wavefield], kwargs[:compressor][active_wavefield], div(it-1,itskip)+1,
+                            wavefields[active_wavefield], ginsu_interior_range)
+                    else
+                        WaveFD.compressedwrite(iofield[active_wavefield], kwargs[:compressor][active_wavefield], div(it-1,itskip)+1,
+                            wavefields[active_wavefield])
+                    end
                 end
             end
         end
@@ -608,6 +616,8 @@ function JopProp2DAcoVTIDenQ_DEO2_FDTD_df!(δd::AbstractArray, δm::AbstractArra
         δm_ginsu[prop] = sub(kwargs[:ginsu], @view(δm[:,:,kwargs[:active_modelset][prop]]), extend=false)
     end
 
+    ginsu_interior_range = interior(kwargs[:ginsu])
+
     # pre-compute receiver interpolation coefficients
     local iz,ix,c
     if kwargs[:interpmethod] == :hicks
@@ -656,8 +666,13 @@ function JopProp2DAcoVTIDenQ_DEO2_FDTD_df!(δd::AbstractArray, δm::AbstractArra
         if rem(it-1,itskip) == 0
             # read source field from disk
             cumtime_io += @elapsed for active_wavefield in kwargs[:active_wavefields]
-                WaveFD.compressedread!(iofields[active_wavefield], kwargs[:compressor][active_wavefield], div(it-1,itskip)+1,
-                    kwargs[:isinterior] ? interior(kwargs[:ginsu], wavefields[active_wavefield]) : wavefields[active_wavefield])
+                if kwargs[:isinterior]
+                    WaveFD.compressedread!(iofields[active_wavefield], kwargs[:compressor][active_wavefield], div(it-1,itskip)+1,
+                        wavefields[active_wavefield], ginsu_interior_range)
+                else
+                    WaveFD.compressedread!(iofields[active_wavefield], kwargs[:compressor][active_wavefield], div(it-1,itskip)+1,
+                        wavefields[active_wavefield])
+                end
             end
 
             # born injection
@@ -723,6 +738,8 @@ function JopProp2DAcoVTIDenQ_DEO2_FDTD_df′!(δm::AbstractArray, δd::AbstractA
         δm_ginsu[prop] = zeros(Float32, nz_ginsu, nx_ginsu)
     end
 
+    ginsu_interior_range = interior(kwargs[:ginsu])
+
     # Get receiver interpolation coefficients
     local iz, ix, c
     if kwargs[:interpmethod] == :hicks
@@ -783,8 +800,13 @@ function JopProp2DAcoVTIDenQ_DEO2_FDTD_df′!(δm::AbstractArray, δd::AbstractA
         if rem(it-1,itskip) == 0
             # read source field from disk
             cumtime_io += @elapsed for active_wavefield in kwargs[:active_wavefields]
-                WaveFD.compressedread!(iofields[active_wavefield], kwargs[:compressor][active_wavefield], div(it-1,itskip)+1,
-                    kwargs[:isinterior] ? interior(kwargs[:ginsu], wavefields[active_wavefield]) : wavefields[active_wavefield])
+                if kwargs[:isinterior]
+                    WaveFD.compressedread!(iofields[active_wavefield], kwargs[:compressor][active_wavefield], div(it-1,itskip)+1,
+                        wavefields[active_wavefield], ginsu_interior_range)
+                else
+                    WaveFD.compressedread!(iofields[active_wavefield], kwargs[:compressor][active_wavefield], div(it-1,itskip)+1,
+                        wavefields[active_wavefield])
+                end
             end
 
             # born accumulation
@@ -834,10 +856,10 @@ end
 
 Jets.perfstat(J::T) where {D,R,T<:Jet{D,R,typeof(JopProp2DAcoVTIDenQ_DEO2_FDTD_f!)}} = state(J).stats
 
-@inline function JopProp2DAcoVTIDenQ_DEO2_FDTD_write_history_ln(ginsu, it, ntmod, cumtime_total, cumtime_io, cumtime_ex, cumtime_im, pcur, d, mode)
+@inline function JopProp2DAcoVTIDenQ_DEO2_FDTD_write_history_ln(ginsu, it, ntmod, cumtime_total, cumtime_io, cumtime_ex, cumtime_im, pcur, d::AbstractArray{T}, mode) where {T}
     itd = occursin("adjoint", mode) ? ntmod-it+1 : it
     rmsp = sqrt(norm(pcur)^2 / length(pcur))
-    rmsd = d != nothing ? sqrt(norm(d)^2 / length(d)) : 0.0
+    rmsd = d != nothing ? sqrt(norm(d)^2 / length(d)) : zero(T)
     @info @sprintf("PropLn2DAcoVTIDenQ_DEO2_FDTD, %s, time step %5d of %5d ; %7.2f MCells/s (IO=%5.2f%%, EX=%5.2f%%, IM=%5.2f%%) -- rms d,p; %10.4e %10.4e", mode, itd, ntmod,
                     megacells_per_second(size(ginsu)..., itd-1, cumtime_total),
                     cumtime_total > 0 ? cumtime_io/cumtime_total*100.0 : 0.0,
@@ -845,9 +867,9 @@ Jets.perfstat(J::T) where {D,R,T<:Jet{D,R,typeof(JopProp2DAcoVTIDenQ_DEO2_FDTD_f
                     cumtime_total > 0 ? cumtime_im/cumtime_total*100.0 : 0.0, rmsd, rmsp)
 end
 
-@inline function JopProp2DAcoVTIDenQ_DEO2_FDTD_write_history_nl(ginsu, it, ntmod, cumtime_total, cumtime_io, cumtime_ex, pcur, d)
+@inline function JopProp2DAcoVTIDenQ_DEO2_FDTD_write_history_nl(ginsu, it, ntmod, cumtime_total, cumtime_io, cumtime_ex, pcur, d::AbstractArray{T}) where {T}
     rmsp = sqrt(norm(pcur)^2 / length(pcur))
-    rmsd = length(d) > 0 ? sqrt(norm(d)^2 / length(d)) : 0.0
+    rmsd = length(d) > 0 ? sqrt(norm(d)^2 / length(d)) : zero(T)
     @info @sprintf("Prop2DAcoVTIDenQ_DEO2_FDTD, nonlinear forward, time step %5d of %5d ; %7.2f MCells/s (IO=%5.2f%%, EX=%5.2f%%) -- rms d,p; %10.4e %10.4e", it, ntmod,
                     megacells_per_second(size(ginsu)..., it-1, cumtime_total),
                     cumtime_total > 0 ? cumtime_io/cumtime_total*100.0 : 0.0,

--- a/src/jop_prop3DAcoIsoDenQ_DEO2_FDTD.jl
+++ b/src/jop_prop3DAcoIsoDenQ_DEO2_FDTD.jl
@@ -358,6 +358,8 @@ function JopProp3DAcoIsoDenQ_DEO2_FDTD_nonlinearforward!(d::AbstractArray, m::Ab
     sub!(m_ginsu, kwargs[:ginsu], m, extend=true)
     sub!(b_ginsu, kwargs[:ginsu], kwargs[:b], extend=true)
 
+    ginsu_interior_range = interior(kwargs[:ginsu])
+
     it0, ntmod_wav = WaveFD.default_ntmod(kwargs[:dtrec], kwargs[:dtmod], kwargs[:st], kwargs[:ntrec])
 
     # source wavelet for injection, one for each source location
@@ -372,13 +374,14 @@ function JopProp3DAcoIsoDenQ_DEO2_FDTD_nonlinearforward!(d::AbstractArray, m::Ab
     end
     blks_sou = WaveFD.source_blocking(nz_ginsu, ny_ginsu, nx_ginsu, kwargs[:nbz_inject], kwargs[:nby_inject], kwargs[:nbx_inject], iz_sou, iy_sou, ix_sou, c_sou)
 
-    c_sou_scaled = deepcopy(c_sou)
+    c_sou_scaled = Array{Array{Float32,3},1}(undef, length(c_sou))
     for i = 1:length(c_sou_scaled)
+        c_sou_scaled[i] = similar(c_sou[i])
         for ix = 1:size(c_sou_scaled[i], 3), iy = 1:size(c_sou_scaled[i], 2), iz = 1:size(c_sou_scaled[i], 1)
             jz = iz_sou[i][iz]
             jy = iy_sou[i][iy]
             jx = ix_sou[i][ix]
-            c_sou_scaled[i][iz,iy,ix] *= kwargs[:dtmod]^2 * m_ginsu[jz,jy,jx]^2 / b_ginsu[jz,jy,jx]
+            c_sou_scaled[i][iz,iy,ix] = c_sou[i][iz,iy,ix] * kwargs[:dtmod]^2 * m_ginsu[jz,jy,jx]^2 / b_ginsu[jz,jy,jx]
         end
     end
     blks_sou_scaled = WaveFD.source_blocking(nz_ginsu, ny_ginsu, nx_ginsu, kwargs[:nbz_inject], kwargs[:nby_inject], kwargs[:nbx_inject], iz_sou, iy_sou, ix_sou, c_sou_scaled)
@@ -397,15 +400,10 @@ function JopProp3DAcoIsoDenQ_DEO2_FDTD_nonlinearforward!(d::AbstractArray, m::Ab
     if kwargs[:srcfieldfile] != ""
         for wavefield_active in ["P","DP"]
             filename = "$(kwargs[:srcfieldfile])-$(wavefield_active)"
-            try
-                if isfile(filename) == true
-                    rm(filename)
-                end
-                iofield[wavefield_active] = open(filename, "w")
-            catch
-                @info "Unable to open $(filename) on proc $(myid()) - $(gethostname())"
-                rethrow()
+            if isfile(filename) == true
+                rm(filename)
             end
+            iofield[wavefield_active] = open(filename, "w")
             open(kwargs[:compressor][wavefield_active])
         end
     end
@@ -441,11 +439,12 @@ function JopProp3DAcoIsoDenQ_DEO2_FDTD_nonlinearforward!(d::AbstractArray, m::Ab
             WaveFD.scale_spatial_derivatives!(p)
 
             if kwargs[:srcfieldfile] != ""
-                cumtime_io += @elapsed begin
-                    WaveFD.compressedwrite(iofield["P"], kwargs[:compressor]["P"],  div(it-1,itskip)+1,
-                        kwargs[:isinterior] ? interior(kwargs[:ginsu], pold) : pold)
-                    WaveFD.compressedwrite(iofield["DP"], kwargs[:compressor]["DP"], div(it-1,itskip)+1,
-                        kwargs[:isinterior] ? interior(kwargs[:ginsu], pspace) : pspace)
+                cumtime_io += @elapsed if kwargs[:isinterior]
+                    WaveFD.compressedwrite(iofield["P"], kwargs[:compressor]["P"],  div(it-1,itskip)+1, pold, ginsu_interior_range)
+                    WaveFD.compressedwrite(iofield["DP"], kwargs[:compressor]["DP"], div(it-1,itskip)+1, pspace, ginsu_interior_range)
+                else
+                    WaveFD.compressedwrite(iofield["P"], kwargs[:compressor]["P"],  div(it-1,itskip)+1, pold)
+                    WaveFD.compressedwrite(iofield["DP"], kwargs[:compressor]["DP"], div(it-1,itskip)+1, pspace)
                 end
             end
         end
@@ -528,6 +527,8 @@ function JopProp3DAcoIsoDenQ_DEO2_FDTD_df!(δd::AbstractArray, δm::AbstractArra
 
     δm_ginsu = sub(kwargs[:ginsu], δm, extend=false)
 
+    ginsu_interior_range = interior(kwargs[:ginsu])
+
     # pre-compute receiver interpolation coefficients
     local iz, iy, ix, c
     if kwargs[:interpmethod] == :hicks
@@ -570,9 +571,11 @@ function JopProp3DAcoIsoDenQ_DEO2_FDTD_df!(δd::AbstractArray, δm::AbstractArra
 
         if rem(it-1,itskip) == 0
             # read source field from disk
-			cumtime_io += @elapsed WaveFD.compressedread!(iofield, kwargs[:compressor]["DP"], div(it-1,itskip)+1,
-                kwargs[:isinterior] ? interior(kwargs[:ginsu], DP) : DP)
-
+            cumtime_io += @elapsed if kwargs[:isinterior]
+                WaveFD.compressedread!(iofield, kwargs[:compressor]["DP"], div(it-1,itskip)+1, DP, ginsu_interior_range)
+            else
+                WaveFD.compressedread!(iofield, kwargs[:compressor]["DP"], div(it-1,itskip)+1, DP)
+            end
             # born injection
             cumtime_im += @elapsed WaveFD.forwardBornInjection!(p, δm_ginsu, DP)
         end
@@ -624,6 +627,8 @@ function JopProp3DAcoIsoDenQ_DEO2_FDTD_df′!(δm::AbstractArray, δd::AbstractA
     sub!(b_ginsu, kwargs[:ginsu], kwargs[:b], extend=true)
 
     δm_ginsu = zeros(Float32, nz_ginsu, ny_ginsu, nx_ginsu)
+
+    ginsu_interior_range = interior(kwargs[:ginsu])
 
     # Get receiver interpolation coefficients
     local iz, iy, ix, c
@@ -681,8 +686,11 @@ function JopProp3DAcoIsoDenQ_DEO2_FDTD_df′!(δm::AbstractArray, δd::AbstractA
 
         if rem(it-1,itskip) == 0
             # read source field from disk
-            cumtime_io += @elapsed WaveFD.compressedread!(iofield, kwargs[:compressor]["DP"], 
-                div(it-1,itskip)+1, kwargs[:isinterior] ? interior(kwargs[:ginsu], DP) : DP)
+            cumtime_io += @elapsed if kwargs[:isinterior]
+                WaveFD.compressedread!(iofield, kwargs[:compressor]["DP"], div(it-1,itskip)+1, DP, ginsu_interior_range)
+            else 
+                WaveFD.compressedread!(iofield, kwargs[:compressor]["DP"], div(it-1,itskip)+1, DP)
+            end
 
             # born accumulation
             cumtime_im += @elapsed WaveFD.adjointBornAccumulation!(p, δm_ginsu, DP)
@@ -725,10 +733,10 @@ end
 
 Jets.perfstat(J::T) where {D,R,T<:Jet{D,R,typeof(JopProp3DAcoIsoDenQ_DEO2_FDTD_f!)}} = state(J).stats
 
-@inline function JopProp3DAcoIsoDenQ_DEO2_FDTD_write_history_ln(ginsu, it, ntmod, cumtime_total, cumtime_io, cumtime_ex, cumtime_im, pcur, d, mode)
+@inline function JopProp3DAcoIsoDenQ_DEO2_FDTD_write_history_ln(ginsu, it, ntmod, cumtime_total, cumtime_io, cumtime_ex, cumtime_im, pcur, d::AbstractArray{T}, mode) where {T}
     itd = occursin("adjoint", mode) ? ntmod-it+1 : it
     rmsp = sqrt(norm(pcur)^2 / length(pcur))
-    rmsd = d != nothing ? sqrt(norm(d)^2 / length(d)) : 0.0
+    rmsd = d != nothing ? sqrt(norm(d)^2 / length(d)) : zero(T)
     @info @sprintf("PropLn3DAcoIsoDenQ_DEO2_FDTD, %s, time step %5d of %5d ; %7.2f MCells/s (IO=%5.2f%%, EX=%5.2f%%, IM=%5.2f%%) -- rms d,p; %10.4e %10.4e", mode, itd, ntmod,
                     megacells_per_second(size(ginsu)..., itd-1, cumtime_total),
                     cumtime_total > 0 ? cumtime_io/cumtime_total*100.0 : 0.0,
@@ -736,9 +744,9 @@ Jets.perfstat(J::T) where {D,R,T<:Jet{D,R,typeof(JopProp3DAcoIsoDenQ_DEO2_FDTD_f
                     cumtime_total > 0 ? cumtime_im/cumtime_total*100.0 : 0.0, rmsd, rmsp)
 end
 
-@inline function JopProp3DAcoIsoDenQ_DEO2_FDTD_write_history_nl(ginsu, it, ntmod, cumtime_total, cumtime_io, cumtime_ex, pcur, d)
+@inline function JopProp3DAcoIsoDenQ_DEO2_FDTD_write_history_nl(ginsu, it, ntmod, cumtime_total, cumtime_io, cumtime_ex, pcur, d::AbstractArray{T}) where {T}
     rmsp = sqrt(norm(pcur)^2 / length(pcur))
-    rmsd = length(d) > 0 ? sqrt(norm(d)^2 / length(d)) : 0.0
+    rmsd = length(d) > 0 ? sqrt(norm(d)^2 / length(d)) : zero(T)
     @info @sprintf("Prop3DAcoIsoDenQ_DEO2_FDTD, nonlinear forward, time step %5d of %5d ; %7.2f MCells/s (IO=%5.2f%%, EX=%5.2f%%) -- rms d,p; %10.4e %10.4e", it, ntmod,
                     megacells_per_second(size(ginsu)..., it-1, cumtime_total),
                     cumtime_total > 0 ? cumtime_io/cumtime_total*100.0 : 0.0,

--- a/src/jop_prop3DAcoTTIDenQ_DEO2_FDTD.jl
+++ b/src/jop_prop3DAcoTTIDenQ_DEO2_FDTD.jl
@@ -71,10 +71,10 @@ function JetProp3DAcoTTIDenQ_DEO2_FDTD(;
     local active_wavefields, modeltype
     if "v" ∈ active_modelset_keys && "b" ∉ active_modelset_keys && "ϵ" ∈ active_modelset_keys && "η" ∈ active_modelset_keys
         active_wavefields = ["pold","mold","pspace","mspace"]
-        modeltype = WaveFD.Prop3DAcoTTIDenQ_DEO2_FDTD_Model_VEA
+        modeltype = WaveFD.Prop3DAcoTTIDenQ_DEO2_FDTD_Model_VEA()
     elseif "v" ∈ active_modelset_keys && "b" ∉ active_modelset_keys && "ϵ" ∉ active_modelset_keys && "η" ∉ active_modelset_keys
         active_wavefields = ["pspace","mspace"]
-        modeltype = WaveFD.Prop3DAcoTTIDenQ_DEO2_FDTD_Model_V
+        modeltype = WaveFD.Prop3DAcoTTIDenQ_DEO2_FDTD_Model_V()
     else
         error("unsupported model-space")
     end
@@ -475,6 +475,8 @@ function JopProp3DAcoTTIDenQ_DEO2_FDTD_nonlinearforward!(d::AbstractArray, m::Ab
     end
     model_ginsu["f"] .= kwargs[:f]
 
+    ginsu_interior_range = interior(kwargs[:ginsu])
+
     # we need to serialize "pold" for the data but, not (necessarily) for the linearization
     active_wavefields = "pold" ∈ kwargs[:active_wavefields] ? kwargs[:active_wavefields] : [kwargs[:active_wavefields]; "pold"]
 
@@ -492,13 +494,14 @@ function JopProp3DAcoTTIDenQ_DEO2_FDTD_nonlinearforward!(d::AbstractArray, m::Ab
     end
     blks_sou = WaveFD.source_blocking(nz_ginsu, ny_ginsu, nx_ginsu, kwargs[:nbz_inject], kwargs[:nby_inject], kwargs[:nbx_inject], iz_sou, iy_sou, ix_sou, c_sou)
 
-    c_sou_scaled = deepcopy(c_sou)
+    c_sou_scaled = Array{Array{Float32,3},1}(undef, length(c_sou))
     for i = 1:length(c_sou_scaled)
+        c_sou_scaled[i] = similar(c_sou[i])
         for ix = 1:size(c_sou_scaled[i], 3), iy = 1:size(c_sou_scaled[i], 2), iz = 1:size(c_sou_scaled[i], 1)
             jz = iz_sou[i][iz]
             jy = iy_sou[i][iy]
             jx = ix_sou[i][ix]
-            c_sou_scaled[i][iz,iy,ix] *= kwargs[:dtmod]^2 * model_ginsu["v"][jz,jy,jx]^2 / model_ginsu["b"][jz,jy,jx]
+            c_sou_scaled[i][iz,iy,ix] = c_sou[i][iz,iy,ix] * kwargs[:dtmod]^2 * model_ginsu["v"][jz,jy,jx]^2 / model_ginsu["b"][jz,jy,jx]
         end
     end
     blks_sou_scaled = WaveFD.source_blocking(nz_ginsu, ny_ginsu, nx_ginsu, kwargs[:nbz_inject], kwargs[:nby_inject], kwargs[:nbx_inject], iz_sou, iy_sou, ix_sou, c_sou_scaled)
@@ -517,15 +520,10 @@ function JopProp3DAcoTTIDenQ_DEO2_FDTD_nonlinearforward!(d::AbstractArray, m::Ab
     if kwargs[:srcfieldfile] != ""
         for active_wavefield in active_wavefields
             filename = "$(kwargs[:srcfieldfile])-$(active_wavefield)"
-            try
-                if isfile(filename) == true
-                    rm(filename)
-                end
-                iofield[active_wavefield] = open(filename, "w")
-            catch
-                @info "Unable to open $(filename) on proc $(myid()) - $(gethostname())"
-                rethrow()
+            if isfile(filename) == true
+                rm(filename)
             end
+            iofield[active_wavefield] = open(filename, "w")
             open(kwargs[:compressor][active_wavefield])
         end
     end
@@ -563,8 +561,13 @@ function JopProp3DAcoTTIDenQ_DEO2_FDTD_nonlinearforward!(d::AbstractArray, m::Ab
 
             if kwargs[:srcfieldfile] != ""
                 cumtime_io += @elapsed for active_wavefield in active_wavefields
-                    WaveFD.compressedwrite(iofield[active_wavefield], kwargs[:compressor][active_wavefield], div(it-1,itskip)+1,
-                        kwargs[:isinterior] ? interior(kwargs[:ginsu], wavefields[active_wavefield]) : wavefields[active_wavefield])
+                    if kwargs[:isinterior]
+                        WaveFD.compressedwrite(iofield[active_wavefield], kwargs[:compressor][active_wavefield], div(it-1,itskip)+1,
+                            wavefields[active_wavefield], ginsu_interior_range)
+                    else
+                        WaveFD.compressedwrite(iofield[active_wavefield], kwargs[:compressor][active_wavefield], div(it-1,itskip)+1,
+                            wavefields[active_wavefield])
+                    end
                 end
             end
         end
@@ -658,6 +661,8 @@ function JopProp3DAcoTTIDenQ_DEO2_FDTD_df!(δd::AbstractArray, δm::AbstractArra
         δm_ginsu[prop] = sub(kwargs[:ginsu], @view(δm[:,:,:,kwargs[:active_modelset][prop]]), extend=false)
     end
 
+    ginsu_interior_range = interior(kwargs[:ginsu])
+
     # pre-compute receiver interpolation coefficients
     local iz,iy,ix,c
     if kwargs[:interpmethod] == :hicks
@@ -706,8 +711,13 @@ function JopProp3DAcoTTIDenQ_DEO2_FDTD_df!(δd::AbstractArray, δm::AbstractArra
         if rem(it-1,itskip) == 0
             # read source field from disk
             cumtime_io += @elapsed for active_wavefield in kwargs[:active_wavefields]
-                WaveFD.compressedread!(iofields[active_wavefield], kwargs[:compressor][active_wavefield], div(it-1,itskip)+1,
-                    kwargs[:isinterior] ? interior(kwargs[:ginsu], wavefields[active_wavefield]) : wavefields[active_wavefield])
+                if kwargs[:isinterior]
+                    WaveFD.compressedread!(iofields[active_wavefield], kwargs[:compressor][active_wavefield], div(it-1,itskip)+1,
+                        wavefields[active_wavefield], ginsu_interior_range)
+                else
+                    WaveFD.compressedread!(iofields[active_wavefield], kwargs[:compressor][active_wavefield], div(it-1,itskip)+1,
+                        wavefields[active_wavefield])
+                end
             end
 
             # born injection
@@ -777,6 +787,8 @@ function JopProp3DAcoTTIDenQ_DEO2_FDTD_df′!(δm::AbstractArray, δd::AbstractA
         δm_ginsu[prop] = zeros(Float32, nz_ginsu, ny_ginsu, nx_ginsu)
     end
 
+    ginsu_interior_range = interior(kwargs[:ginsu])
+
     # Get receiver interpolation coefficients
     local iz,iy,ix,c
     if kwargs[:interpmethod] == :hicks
@@ -840,8 +852,13 @@ function JopProp3DAcoTTIDenQ_DEO2_FDTD_df′!(δm::AbstractArray, δd::AbstractA
         if rem(it-1,itskip) == 0
             # read source field from disk
             cumtime_io += @elapsed for active_wavefield in kwargs[:active_wavefields]
-                WaveFD.compressedread!(iofields[active_wavefield], kwargs[:compressor][active_wavefield], div(it-1,itskip)+1,
-                    kwargs[:isinterior] ? interior(kwargs[:ginsu], wavefields[active_wavefield]) : wavefields[active_wavefield])
+                if kwargs[:isinterior]
+                    WaveFD.compressedread!(iofields[active_wavefield], kwargs[:compressor][active_wavefield], div(it-1,itskip)+1,
+                        wavefields[active_wavefield], ginsu_interior_range)
+                else
+                    WaveFD.compressedread!(iofields[active_wavefield], kwargs[:compressor][active_wavefield], div(it-1,itskip)+1,
+                        wavefields[active_wavefield])
+                end
             end
 
             # born accumulation
@@ -891,10 +908,10 @@ end
 
 Jets.perfstat(J::T) where {D,R,T<:Jet{D,R,typeof(JopProp3DAcoTTIDenQ_DEO2_FDTD_f!)}} = state(J).stats
 
-@inline function JopProp3DAcoTTIDenQ_DEO2_FDTD_write_history_ln(ginsu, it, ntmod, cumtime_total, cumtime_io, cumtime_ex, cumtime_im, pcur, d, mode)
+@inline function JopProp3DAcoTTIDenQ_DEO2_FDTD_write_history_ln(ginsu, it, ntmod, cumtime_total, cumtime_io, cumtime_ex, cumtime_im, pcur, d::AbstractArray{T}, mode) where {T}
     itd = occursin("adjoint", mode) ? ntmod-it+1 : it
     rmsp = sqrt(norm(pcur)^2 / length(pcur))
-    rmsd = d != nothing ? sqrt(norm(d)^2 / length(d)) : 0.0
+    rmsd = d != nothing ? sqrt(norm(d)^2 / length(d)) : zero(T)
     @info @sprintf("PropLn3DAcoTTIDenQ_DEO2_FDTD, %s, time step %5d of %5d ; %7.2f MCells/s (IO=%5.2f%%, EX=%5.2f%%, IM=%5.2f%%) -- rms d,p; %10.4e %10.4e", mode, itd, ntmod,
                     megacells_per_second(size(ginsu)..., itd-1, cumtime_total),
                     cumtime_total > 0 ? cumtime_io/cumtime_total*100.0 : 0.0,
@@ -902,9 +919,9 @@ Jets.perfstat(J::T) where {D,R,T<:Jet{D,R,typeof(JopProp3DAcoTTIDenQ_DEO2_FDTD_f
                     cumtime_total > 0 ? cumtime_im/cumtime_total*100.0 : 0.0, rmsd, rmsp)
 end
 
-@inline function JopProp3DAcoTTIDenQ_DEO2_FDTD_write_history_nl(ginsu, it, ntmod, cumtime_total, cumtime_io, cumtime_ex, pcur, d)
+@inline function JopProp3DAcoTTIDenQ_DEO2_FDTD_write_history_nl(ginsu, it, ntmod, cumtime_total, cumtime_io, cumtime_ex, pcur, d::AbstractArray{T}) where {T}
     rmsp = sqrt(norm(pcur)^2 / length(pcur))
-    rmsd = length(d) > 0 ? sqrt(norm(d)^2 / length(d)) : 0.0
+    rmsd = length(d) > 0 ? sqrt(norm(d)^2 / length(d)) : zero(T)
     @info @sprintf("Prop3DAcoTTIDenQ_DEO2_FDTD, nonlinear forward, time step %5d of %5d ; %7.2f MCells/s (IO=%5.2f%%, EX=%5.2f%%) -- rms d,p; %10.4e %10.4e", it, ntmod,
                     megacells_per_second(size(ginsu)..., it-1, cumtime_total),
                     cumtime_total > 0 ? cumtime_io/cumtime_total*100.0 : 0.0,

--- a/src/jop_prop3DAcoVTIDenQ_DEO2_FDTD.jl
+++ b/src/jop_prop3DAcoVTIDenQ_DEO2_FDTD.jl
@@ -65,10 +65,10 @@ function JetProp3DAcoVTIDenQ_DEO2_FDTD(;
     local active_wavefields, modeltype
     if "v" ∈ active_modelset_keys && "b" ∉ active_modelset_keys && "ϵ" ∈ active_modelset_keys && "η" ∈ active_modelset_keys
         active_wavefields = ["pold","mold","pspace","mspace"]
-        modeltype = WaveFD.Prop3DAcoVTIDenQ_DEO2_FDTD_Model_VEA
+        modeltype = WaveFD.Prop3DAcoVTIDenQ_DEO2_FDTD_Model_VEA()
     elseif "v" ∈ active_modelset_keys && "b" ∉ active_modelset_keys && "ϵ" ∉ active_modelset_keys && "η" ∉ active_modelset_keys
         active_wavefields = ["pspace","mspace"]
-        modeltype = WaveFD.Prop3DAcoVTIDenQ_DEO2_FDTD_Model_V
+        modeltype = WaveFD.Prop3DAcoVTIDenQ_DEO2_FDTD_Model_V()
     else
         error("unsupported model-space")
     end
@@ -460,6 +460,8 @@ function JopProp3DAcoVTIDenQ_DEO2_FDTD_nonlinearforward!(d::AbstractArray, m::Ab
     end
     model_ginsu["f"] .= kwargs[:f]
 
+    ginsu_interior_range = interior(kwargs[:ginsu])
+
     # we need to serialize "pold" for the data but, not (necessarily) for the linearization
     active_wavefields = "pold" ∈ kwargs[:active_wavefields] ? kwargs[:active_wavefields] : [kwargs[:active_wavefields]; "pold"]
 
@@ -477,13 +479,14 @@ function JopProp3DAcoVTIDenQ_DEO2_FDTD_nonlinearforward!(d::AbstractArray, m::Ab
     end
     blks_sou = WaveFD.source_blocking(nz_ginsu, ny_ginsu, nx_ginsu, kwargs[:nbz_inject], kwargs[:nby_inject], kwargs[:nbx_inject], iz_sou, iy_sou, ix_sou, c_sou)
 
-    c_sou_scaled = deepcopy(c_sou)
+    c_sou_scaled = Array{Array{Float32,3},1}(undef, length(c_sou))
     for i = 1:length(c_sou_scaled)
+        c_sou_scaled[i] = similar(c_sou[i])
         for ix = 1:size(c_sou_scaled[i], 3), iy = 1:size(c_sou_scaled[i], 2), iz = 1:size(c_sou_scaled[i], 1)
             jz = iz_sou[i][iz]
             jy = iy_sou[i][iy]
             jx = ix_sou[i][ix]
-            c_sou_scaled[i][iz,iy,ix] *= kwargs[:dtmod]^2 * model_ginsu["v"][jz,jy,jx]^2 / model_ginsu["b"][jz,jy,jx]
+            c_sou_scaled[i][iz,iy,ix] = c_sou[i][iz,iy,ix] * kwargs[:dtmod]^2 * model_ginsu["v"][jz,jy,jx]^2 / model_ginsu["b"][jz,jy,jx]
         end
     end
     blks_sou_scaled = WaveFD.source_blocking(nz_ginsu, ny_ginsu, nx_ginsu, kwargs[:nbz_inject], kwargs[:nby_inject], kwargs[:nbx_inject], iz_sou, iy_sou, ix_sou, c_sou_scaled)
@@ -502,15 +505,10 @@ function JopProp3DAcoVTIDenQ_DEO2_FDTD_nonlinearforward!(d::AbstractArray, m::Ab
     if kwargs[:srcfieldfile] != ""
         for active_wavefield in active_wavefields
             filename = "$(kwargs[:srcfieldfile])-$(active_wavefield)"
-            try
-                if isfile(filename) == true
-                    rm(filename)
-                end
-                iofield[active_wavefield] = open(filename, "w")
-            catch
-                @info "Unable to open $(filename) on proc $(myid()) - $(gethostname())"
-                rethrow()
+            if isfile(filename) == true
+                rm(filename)
             end
+            iofield[active_wavefield] = open(filename, "w")
             open(kwargs[:compressor][active_wavefield])
         end
     end
@@ -548,8 +546,13 @@ function JopProp3DAcoVTIDenQ_DEO2_FDTD_nonlinearforward!(d::AbstractArray, m::Ab
 
             if kwargs[:srcfieldfile] != ""
                 cumtime_io += @elapsed for active_wavefield in active_wavefields
-                    WaveFD.compressedwrite(iofield[active_wavefield], kwargs[:compressor][active_wavefield], div(it-1,itskip)+1,
-                        kwargs[:isinterior] ? interior(kwargs[:ginsu], wavefields[active_wavefield]) : wavefields[active_wavefield])
+                    if kwargs[:isinterior]
+                        WaveFD.compressedwrite(iofield[active_wavefield], kwargs[:compressor][active_wavefield], div(it-1,itskip)+1,
+                            wavefields[active_wavefield], ginsu_interior_range)
+                    else
+                        WaveFD.compressedwrite(iofield[active_wavefield], kwargs[:compressor][active_wavefield], div(it-1,itskip)+1,
+                            wavefields[active_wavefield])
+                    end
                 end
             end
         end
@@ -642,6 +645,8 @@ function JopProp3DAcoVTIDenQ_DEO2_FDTD_df!(δd::AbstractArray, δm::AbstractArra
         δm_ginsu[prop] = sub(kwargs[:ginsu], @view(δm[:,:,:,kwargs[:active_modelset][prop]]), extend=false)
     end
 
+    ginsu_interior_range = interior(kwargs[:ginsu])
+
     # pre-compute receiver interpolation coefficients
     local iz,iy,ix,c
     if kwargs[:interpmethod] == :hicks
@@ -690,8 +695,13 @@ function JopProp3DAcoVTIDenQ_DEO2_FDTD_df!(δd::AbstractArray, δm::AbstractArra
         if rem(it-1,itskip) == 0
             # read source field from disk
             cumtime_io += @elapsed for active_wavefield in kwargs[:active_wavefields]
-                WaveFD.compressedread!(iofields[active_wavefield], kwargs[:compressor][active_wavefield], div(it-1,itskip)+1,
-                    kwargs[:isinterior] ? interior(kwargs[:ginsu], wavefields[active_wavefield]) : wavefields[active_wavefield])
+                if kwargs[:isinterior]
+                    WaveFD.compressedread!(iofields[active_wavefield], kwargs[:compressor][active_wavefield], div(it-1,itskip)+1,
+                        wavefields[active_wavefield], ginsu_interior_range)
+                else
+                    WaveFD.compressedread!(iofields[active_wavefield], kwargs[:compressor][active_wavefield], div(it-1,itskip)+1,
+                        wavefields[active_wavefield])
+                end
             end
 
             # born injection
@@ -760,6 +770,8 @@ function JopProp3DAcoVTIDenQ_DEO2_FDTD_df′!(δm::AbstractArray, δd::AbstractA
         δm_ginsu[prop] = zeros(Float32, nz_ginsu, ny_ginsu, nx_ginsu)
     end
 
+    ginsu_interior_range = interior(kwargs[:ginsu])
+
     # Get receiver interpolation coefficients
     local iz, iy, ix, c
     if kwargs[:interpmethod] == :hicks
@@ -823,8 +835,13 @@ function JopProp3DAcoVTIDenQ_DEO2_FDTD_df′!(δm::AbstractArray, δd::AbstractA
         if rem(it-1,itskip) == 0
             # read source field from disk
             cumtime_io += @elapsed for active_wavefield in kwargs[:active_wavefields]
-                WaveFD.compressedread!(iofields[active_wavefield], kwargs[:compressor][active_wavefield], div(it-1,itskip)+1,
-                    kwargs[:isinterior] ? interior(kwargs[:ginsu], wavefields[active_wavefield]) : wavefields[active_wavefield])
+                if kwargs[:isinterior]
+                    WaveFD.compressedread!(iofields[active_wavefield], kwargs[:compressor][active_wavefield], div(it-1,itskip)+1,
+                        wavefields[active_wavefield], ginsu_interior_range)
+                else
+                    WaveFD.compressedread!(iofields[active_wavefield], kwargs[:compressor][active_wavefield], div(it-1,itskip)+1,
+                        wavefields[active_wavefield])
+                end
             end
 
             # born accumulation
@@ -874,10 +891,10 @@ end
 
 Jets.perfstat(J::T) where {D,R,T<:Jet{D,R,typeof(JopProp3DAcoVTIDenQ_DEO2_FDTD_f!)}} = state(J).stats
 
-@inline function JopProp3DAcoVTIDenQ_DEO2_FDTD_write_history_ln(ginsu, it, ntmod, cumtime_total, cumtime_io, cumtime_ex, cumtime_im, pcur, d, mode)
+@inline function JopProp3DAcoVTIDenQ_DEO2_FDTD_write_history_ln(ginsu, it, ntmod, cumtime_total, cumtime_io, cumtime_ex, cumtime_im, pcur, d::AbstractArray{T}, mode) where {T}
     itd = occursin("adjoint", mode) ? ntmod-it+1 : it
     rmsp = sqrt(norm(pcur)^2 / length(pcur))
-    rmsd = d != nothing ? sqrt(norm(d)^2 / length(d)) : 0.0
+    rmsd = d != nothing ? sqrt(norm(d)^2 / length(d)) : zero(T)
     @info @sprintf("PropLn3DAcoVTIDenQ_DEO2_FDTD, %s, time step %5d of %5d ; %7.2f MCells/s (IO=%5.2f%%, EX=%5.2f%%, IM=%5.2f%%) -- rms d,p; %10.4e %10.4e", mode, itd, ntmod,
                     megacells_per_second(size(ginsu)..., itd-1, cumtime_total),
                     cumtime_total > 0 ? cumtime_io/cumtime_total*100.0 : 0.0,
@@ -885,9 +902,9 @@ Jets.perfstat(J::T) where {D,R,T<:Jet{D,R,typeof(JopProp3DAcoVTIDenQ_DEO2_FDTD_f
                     cumtime_total > 0 ? cumtime_im/cumtime_total*100.0 : 0.0, rmsd, rmsp)
 end
 
-@inline function JopProp3DAcoVTIDenQ_DEO2_FDTD_write_history_nl(ginsu, it, ntmod, cumtime_total, cumtime_io, cumtime_ex, pcur, d)
+@inline function JopProp3DAcoVTIDenQ_DEO2_FDTD_write_history_nl(ginsu, it, ntmod, cumtime_total, cumtime_io, cumtime_ex, pcur, d::AbstractArray{T}) where {T}
     rmsp = sqrt(norm(pcur)^2 / length(pcur))
-    rmsd = length(d) > 0 ? sqrt(norm(d)^2 / length(d)) : 0.0
+    rmsd = length(d) > 0 ? sqrt(norm(d)^2 / length(d)) : zero(T)
     @info @sprintf("Prop3DAcoVTIDenQ_DEO2_FDTD, nonlinear forward, time step %5d of %5d ; %7.2f MCells/s (IO=%5.2f%%, EX=%5.2f%%) -- rms d,p; %10.4e %10.4e", it, ntmod,
                     megacells_per_second(size(ginsu)..., it-1, cumtime_total),
                     cumtime_total > 0 ? cumtime_io/cumtime_total*100.0 : 0.0,


### PR DESCRIPTION
Consider the following code:
```julia
using JetPackWaveFD, Jets, Cthulhu
nz,nx,nbz,nbx,nthreads=501,1001,501,8,8

F =  JopNlProp2DAcoIsoDenQ_DEO2_FDTD(
               b = ones(Float32,nz,nx),
               srcfieldfile = "",
               comptype = nothing,
               sz = 10.0,
               sx = 10.0*div(nx,2),
               rz = 20.0*ones(nx),
               rx = 10.0*[0:nx-1;],
               dz = 10.0,
               dx = 10.0,
               dtmod = 0.001,
               dtrec = 0.004,
               ntrec = 10,
               nbz_cache = nbz,
               nbx_cache = nbx,
               freesurface = true,
               nthreads = nthreads,
               reportinterval = 0)

s = state(F)
m = 1500*ones(domain(F))
d = zeros(range(F))

@descend_code_warntype JetPackWaveFD.JopProp2DAcoIsoDenQ_DEO2_FDTD_nonlinearforward!(d, m; s...)
```

According to Cthullhu, on master the portion of the code that computes `c_sou_scaled` gives the following inference issues:
```julia
│     %587  = invoke %582(%46::Int64, %99::Int64, %584::Int64, %586::Int64, %581::Array{Array{Int64,1},1}, %580::Array{Array{Int64,1},1}, %579::Array{Array{Float32,2},1})::Array{WaveFD.SourceBlock{Float32,2},2}
│     @ /home/cvx/.julia/dev/JetPackWaveFD/src/jop_prop2DAcoIsoDenQ_DEO2_FDTD.jl:347 within `#JopProp2DAcoIsoDenQ_DEO2_FDTD_nonlinearforward!#76'
│    ┌ @ deepcopy.jl:26 within `deepcopy'
│    │┌ @ iddict.jl:33 within `IdDict' @ iddict.jl:15
│    ││┌ @ boot.jl:406 within `Array'
│    │││ %588  = $(Expr(:foreigncall, :(:jl_alloc_array_1d), Array{Any,1}, svec(Any, Int64), 0, :(:ccall), Array{Any,1}, 32, 32))::Array{Any,1}
│    ││└
│    ││ %589  = %new(IdDict{Any,Any}, %588, 0, 0)::IdDict{Any,Any}
│    │└
│    │┌ @ deepcopy.jl:89 within `deepcopy_internal'
│    ││┌ @ abstractdict.jl:17 within `haskey'
│    │││┌ @ iddict.jl:158 within `in'
│    ││││ %590  = Base.secret_table_token::Symbol
│    ││││┌ @ iddict.jl:87 within `get'
│    │││││┌ @ Base.jl:33 within `getproperty'
│    ││││││ %591  = Base.getfield(%589, :ht)::Array{Any,1}
│    │││││└
│    │││││ %592  = $(Expr(:foreigncall, :(:jl_eqtable_get), Any, svec(Any, Any, Any), 0, :(:ccall), :(%591), :(%579), :(%590)))::Any
│    │││││ @ iddict.jl:88 within `get'
│    │││││ %593  = (%592 === %590)::Bool
└────│││││         goto #265 if not %593
264 ─│││││         goto #266
265 ─│││││         goto #266
     ││││└
266 ┄││││ %597  = φ (#264 => %590, #265 => %592)::Any
│    ││││ %598  = (%597 === Base.secret_table_token)::Bool
│    ││││ %599  = Core.Intrinsics.not_int(%598)::Bool
└────││││         goto #267
     │││└
267 ─│││         goto #268
     ││└
268 ─││         goto #276 if not %599
     ││ @ deepcopy.jl:90 within `deepcopy_internal'
     ││┌ @ iddict.jl:91 within `getindex'
269 ─│││ %603  = Base.secret_table_token::Symbol
│    │││┌ @ iddict.jl:87 within `get'
│    ││││┌ @ Base.jl:33 within `getproperty'
│    │││││ %604  = Base.getfield(%589, :ht)::Array{Any,1}
│    ││││└
│    ││││ %605  = $(Expr(:foreigncall, :(:jl_eqtable_get), Any, svec(Any, Any, Any), 0, :(:ccall), :(%604), :(%579), :(%603)))::Any
│    ││││ @ iddict.jl:88 within `get'
│    ││││ %606  = (%605 === %603)::Bool
└────││││         goto #271 if not %606
270 ─││││         goto #272
271 ─││││         goto #272
     │││└
272 ┄│││ %610  = φ (#270 => %603, #271 => %605)::Any
│    │││ @ iddict.jl:92 within `getindex'
```

With this branch, those inference issues go away:
```julia
F =  JopNlProp2DAcoIsoDenQ_DEO2_FDTD(
               b = ones(Float32,nz,nx),
               srcfieldfile = "",
               comptype = nothing,
               sz = 10.0,
               sx = 10.0*div(nx,2),
               rz = 20.0*ones(nx),
               rx = 10.0*[0:nx-1;],
               dz = 10.0,
               dx = 10.0,
               dtmod = 0.001,
               dtrec = 0.004,
               ntrec = 10,
               nbz_cache = nbz,
               nbx_cache = nbx,
               freesurface = true,
               nthreads = nthreads,
               reportinterval = 0)

s = state(F)
m = 1500*ones(domain(F))
d = zeros(range(F))

@descend_code_warntype JetPackWaveFD.JopProp2DAcoIsoDenQ_DEO2_FDTD_nonlinearforward!(d, m; s...)
```

I guess that this might imply an issue with `deepcopy`.  However, when trying to reproduce the issue with a simple example, I failed:
```julia
function foo()
    x = [rand(8,8) for i = 1:10]
    y = deepcopy(x)
end
@code_warntype foo()
```
which gives:
```
Variables
  #self#::Core.Compiler.Const(foo, false)
  #1::var"#1#2"
  x::Array{Array{Float64,2},1}
  y::Array{Array{Float64,2},1}

Body::Array{Array{Float64,2},1}
1 ─      (#1 = %new(Main.:(var"#1#2")))
│   %2 = #1::Core.Compiler.Const(var"#1#2"(), false)
│   %3 = (1:10)::Core.Compiler.Const(1:10, false)
│   %4 = Base.Generator(%2, %3)::Core.Compiler.Const(Base.Generator{UnitRange{Int64},var"#1#2"}(var"#1#2"(), 1:10), false)
│        (x = Base.collect(%4))
│   %6 = Main.deepcopy(x)::Array{Array{Float64,2},1}
│        (y = %6)
└──      return %6
```

master:
```julia
using LinearAlgebra
@btime mul!(d,F,m)
```
gives
```
42.333 ms (99641 allocations: 14.87 MiB)
```

while this PR gives
```
39.074 ms (99639 allocations: 14.87 MiB)
```

