### PR TITLE
Fix timers

### DIFF
--- a/src/jop_prop2DAcoIsoDenQ_DEO2_FDTD.jl
+++ b/src/jop_prop2DAcoIsoDenQ_DEO2_FDTD.jl
@@ -378,17 +378,17 @@ function JopProp2DAcoIsoDenQ_DEO2_FDTD_nonlinearforward!(d::AbstractArray, m::Ab
 
     itskip = round(Int, kwargs[:dtrec]/kwargs[:dtmod])
     time1 = time()
-    cumtime_io, cumtime_ex = 0.0, 0.0
+    cumtime_io, cumtime_ex, cumtime_pr = 0.0, 0.0, 0.0
     kwargs[:reportinterval] == 0 || @info "nonlinear forward on $(gethostname()), srcfieldfile=$(kwargs[:srcfieldfile])"
 
     set_zero_subnormals(true)
     for it = 1:ntmod_wav
         if kwargs[:reportinterval] != 0 && (it % kwargs[:reportinterval] == 0 || it == ntmod_wav)
-            JopProp2DAcoIsoDenQ_DEO2_FDTD_write_history_nl(kwargs[:ginsu], it, ntmod_wav, time()-time1, cumtime_io, cumtime_ex, pcur, d)
+            JopProp2DAcoIsoDenQ_DEO2_FDTD_write_history_nl(kwargs[:ginsu], it, ntmod_wav, time()-time1, cumtime_io, cumtime_ex, cumtime_pr, pcur, d)
         end
 
         # propagate and wavefield swap
-        WaveFD.propagateforward!(p)
+        cumtime_pr += @elapsed WaveFD.propagateforward!(p)
         pcur,pold = pold,pcur
 
         # inject source wavelet
@@ -400,7 +400,7 @@ function JopProp2DAcoIsoDenQ_DEO2_FDTD_nonlinearforward!(d::AbstractArray, m::Ab
         if it >= it0 && rem(it-1,itskip) == 0
             if length(d) > 0
                 # extract receiver data
-                WaveFD.extractdata!(d, pold, div(it-1,itskip)+1, iz_rec, ix_rec, c_rec)
+                cumtime_ex += @elapsed WaveFD.extractdata!(d, pold, div(it-1,itskip)+1, iz_rec, ix_rec, c_rec)
             end
 
             # scale spatial derivatives by v^2/b to make them temporal derivatives
@@ -522,16 +522,16 @@ function JopProp2DAcoIsoDenQ_DEO2_FDTD_df!(δd::AbstractArray, δm::AbstractArra
     itskip = round(Int, kwargs[:dtrec]/kwargs[:dtmod])
     kwargs[:reportinterval] == 0 || @info "linear forward on $(gethostname()), srcfieldfile=$(kwargs[:srcfieldfile])"
     time1 = time()
-    cumtime_io, cumtime_ex, cumtime_im = 0.0, 0.0, 0.0
+    cumtime_io, cumtime_ex, cumtime_im, cumtime_pr = 0.0, 0.0, 0.0, 0.0
 
     set_zero_subnormals(true)
     for it = 1:ntmod
         if kwargs[:reportinterval] != 0 && (it % kwargs[:reportinterval] == 0 || it == ntmod)
-            JopProp2DAcoIsoDenQ_DEO2_FDTD_write_history_ln(kwargs[:ginsu], it, ntmod, time()-time1, cumtime_io, cumtime_ex, cumtime_im, pcur, δdinterp, "forward")
+            JopProp2DAcoIsoDenQ_DEO2_FDTD_write_history_ln(kwargs[:ginsu], it, ntmod, time()-time1, cumtime_io, cumtime_ex, cumtime_im, cumtime_pr, pcur, δdinterp, "forward")
         end
 
         # propagate and swap wavefields
-        WaveFD.propagateforward!(p)
+        cumtime_pr += @elapsed WaveFD.propagateforward!(p)
         pcur,pold = pold,pcur
 
         if rem(it-1,itskip) == 0
@@ -630,16 +630,16 @@ function JopProp2DAcoIsoDenQ_DEO2_FDTD_df′!(δm::AbstractArray, δd::AbstractA
     itskip = round(Int, kwargs[:dtrec]/kwargs[:dtmod])
     kwargs[:reportinterval] == 0 || @info "linear adjoint on $(gethostname()), srcfieldfile=$(kwargs[:srcfieldfile])"
     time1 = time()
-    cumtime_io, cumtime_ex, cumtime_im = 0.0, 0.0, 0.0
+    cumtime_io, cumtime_ex, cumtime_im, cumtime_pr = 0.0, 0.0, 0.0, 0.0
 
     set_zero_subnormals(true)
     for it = ntmod:-1:1
         if kwargs[:reportinterval] != 0 && (it % kwargs[:reportinterval] == 0 || it == ntmod)
-            JopProp2DAcoIsoDenQ_DEO2_FDTD_write_history_ln(kwargs[:ginsu], it, ntmod, time()-time1, cumtime_io, cumtime_ex, cumtime_im, pcur, δdinterp, "adjoint")
+            JopProp2DAcoIsoDenQ_DEO2_FDTD_write_history_ln(kwargs[:ginsu], it, ntmod, time()-time1, cumtime_io, cumtime_ex, cumtime_im, cumtime_pr, pcur, δdinterp, "adjoint")
         end
 
         # propagate and wavefield swap
-        WaveFD.propagateadjoint!(p)
+        cumtime_pr += @elapsed WaveFD.propagateadjoint!(p)
         pcur,pold = pold,pcur
 
         # inject receiver data
@@ -694,24 +694,26 @@ end
 
 Jets.perfstat(J::T) where {D,R,T<:Jet{D,R,typeof(JopProp2DAcoIsoDenQ_DEO2_FDTD_f!)}} = state(J).stats
 
-@inline function JopProp2DAcoIsoDenQ_DEO2_FDTD_write_history_ln(ginsu, it, ntmod, cumtime_total, cumtime_io, cumtime_ex, cumtime_im, pcur, d::AbstractArray{T}, mode) where {T}
+@inline function JopProp2DAcoIsoDenQ_DEO2_FDTD_write_history_ln(ginsu, it, ntmod, cumtime_total, cumtime_io, cumtime_ex, cumtime_im, cumtime_pr, pcur, d::AbstractArray{T}, mode) where {T}
     itd = occursin("adjoint", mode) ? ntmod-it+1 : it
     rmsp = sqrt(norm(pcur)^2 / length(pcur))
     rmsd = d != nothing ? sqrt(norm(d)^2 / length(d)) : zero(T)
-    @info @sprintf("PropLn2DAcoIsoDenQ_DEO2_FDTD, %s, time step %5d of %5d ; %7.2f MCells/s (IO=%5.2f%%, EX=%5.2f%%, IM=%5.2f%%) -- rms d,p; %10.4e %10.4e", mode, itd, ntmod,
+    @info @sprintf("PropLn2DAcoIsoDenQ_DEO2_FDTD, %s, time step %5d of %5d ; %7.2f MCells/s (IO=%5.2f%%, EX=%5.2f%%, IM=%5.2f%%, PR=%5.2f%%) -- rms d,p; %10.4e %10.4e", mode, itd, ntmod,
                     megacells_per_second(size(ginsu)..., itd-1, cumtime_total),
                     cumtime_total > 0 ? cumtime_io/cumtime_total*100.0 : 0.0,
                     cumtime_total > 0 ? cumtime_ex/cumtime_total*100.0 : 0.0,
-                    cumtime_total > 0 ? cumtime_im/cumtime_total*100.0 : 0.0, rmsd, rmsp)
+                    cumtime_total > 0 ? cumtime_im/cumtime_total*100.0 : 0.0,
+                    cumtime_total > 0 ? cumtime_pr/cumtime_total*100.0 : 0.0, rmsd, rmsp)
 end
 
-@inline function JopProp2DAcoIsoDenQ_DEO2_FDTD_write_history_nl(ginsu, it, ntmod, cumtime_total, cumtime_io, cumtime_ex, pcur, d::AbstractArray{T}) where {T}
+@inline function JopProp2DAcoIsoDenQ_DEO2_FDTD_write_history_nl(ginsu, it, ntmod, cumtime_total, cumtime_io, cumtime_ex, cumtime_pr, pcur, d::AbstractArray{T}) where {T}
     rmsp = sqrt(norm(pcur)^2 / length(pcur))
     rmsd = length(d) > 0 ? sqrt(norm(d)^2 / length(d)) : zero(T)
-    @info @sprintf("Prop2DAcoIsoDenQ_DEO2_FDTD, nonlinear forward, time step %5d of %5d ; %7.2f MCells/s (IO=%5.2f%%, EX=%5.2f%%) -- rms d,p; %10.4e %10.4e", it, ntmod,
+    @info @sprintf("Prop2DAcoIsoDenQ_DEO2_FDTD, nonlinear forward, time step %5d of %5d ; %7.2f MCells/s (IO=%5.2f%%, EX=%5.2f%%, PR=%5.2f%%) -- rms d,p; %10.4e %10.4e", it, ntmod,
                     megacells_per_second(size(ginsu)..., it-1, cumtime_total),
                     cumtime_total > 0 ? cumtime_io/cumtime_total*100.0 : 0.0,
-                    cumtime_total > 0 ? cumtime_ex/cumtime_total*100.0 : 0.0, rmsd, rmsp)
+                    cumtime_total > 0 ? cumtime_ex/cumtime_total*100.0 : 0.0,
+                    cumtime_total > 0 ? cumtime_pr/cumtime_total*100.0 : 0.0, rmsd, rmsp)
 end
 
 function Base.close(jet::Jet{D,R,typeof(JopProp2DAcoIsoDenQ_DEO2_FDTD_f!)}) where {D,R}

--- a/src/jop_prop2DAcoTTIDenQ_DEO2_FDTD.jl
+++ b/src/jop_prop2DAcoTTIDenQ_DEO2_FDTD.jl
@@ -492,17 +492,17 @@ function JopProp2DAcoTTIDenQ_DEO2_FDTD_nonlinearforward!(d::AbstractArray, m::Ab
 
     itskip = round(Int, kwargs[:dtrec]/kwargs[:dtmod])
     time1 = time()
-    cumtime_io, cumtime_ex = 0.0, 0.0
+    cumtime_io, cumtime_ex, cumtime_pr = 0.0, 0.0, 0.0
     kwargs[:reportinterval] == 0 || @info "nonlinear forward on $(gethostname()), srcfieldfile=$(kwargs[:srcfieldfile])"
 
     set_zero_subnormals(true)
     for it = 1:ntmod_wav
         if kwargs[:reportinterval] != 0 && (it % kwargs[:reportinterval] == 0 || it == ntmod_wav)
-            JopProp2DAcoTTIDenQ_DEO2_FDTD_write_history_nl(kwargs[:ginsu], it, ntmod_wav, time()-time1, cumtime_io, cumtime_ex, wavefields["pcur"], d)
+            JopProp2DAcoTTIDenQ_DEO2_FDTD_write_history_nl(kwargs[:ginsu], it, ntmod_wav, time()-time1, cumtime_io, cumtime_ex, cumtime_pr, wavefields["pcur"], d)
         end
 
         # propagate and wavefield swap
-        WaveFD.propagateforward!(p)
+        cumtime_pr += @elapsed WaveFD.propagateforward!(p)
         wavefields["pcur"],wavefields["pold"] = wavefields["pold"],wavefields["pcur"]
         wavefields["mcur"],wavefields["mold"] = wavefields["mold"],wavefields["mcur"]
 
@@ -515,7 +515,7 @@ function JopProp2DAcoTTIDenQ_DEO2_FDTD_nonlinearforward!(d::AbstractArray, m::Ab
         if it >= it0 && rem(it-1,itskip) == 0
             if length(d) > 0
                 # extract receiver data
-                WaveFD.extractdata!(d, wavefields["pold"], div(it-1,itskip)+1, iz_rec, ix_rec, c_rec)
+                cumtime_ex += @elapsed WaveFD.extractdata!(d, wavefields["pold"], div(it-1,itskip)+1, iz_rec, ix_rec, c_rec)
             end
 
             # scale spatial derivatives by v^2/b to make them temporal derivatives
@@ -652,17 +652,17 @@ function JopProp2DAcoTTIDenQ_DEO2_FDTD_df!(δd::AbstractArray, δm::AbstractArra
     itskip = round(Int, kwargs[:dtrec]/kwargs[:dtmod])
     kwargs[:reportinterval] == 0 || @info "linear forward on $(gethostname()), srcfieldfile=$(kwargs[:srcfieldfile])"
     time1 = time()
-    cumtime_io, cumtime_ex, cumtime_im = 0.0, 0.0, 0.0
+    cumtime_io, cumtime_ex, cumtime_im, cumtime_pr = 0.0, 0.0, 0.0, 0.0
 
     set_zero_subnormals(true)
     for it = 1:ntmod
         if kwargs[:reportinterval] != 0 && (it % kwargs[:reportinterval] == 0 || it == ntmod)
             JopProp2DAcoTTIDenQ_DEO2_FDTD_write_history_ln(kwargs[:ginsu], it, ntmod, time()-time1, 
-                cumtime_io, cumtime_ex, cumtime_im, pcur, δdinterp, "forward")
+                cumtime_io, cumtime_ex, cumtime_im, cumtime_pr, pcur, δdinterp, "forward")
         end
 
         # propagate and swap wavefields
-        WaveFD.propagateforward!(p)
+        cumtime_pr += @elapsed WaveFD.propagateforward!(p)
         pcur,pold = pold,pcur
 
         if rem(it-1,itskip) == 0
@@ -783,16 +783,16 @@ function JopProp2DAcoTTIDenQ_DEO2_FDTD_df′!(δm::AbstractArray, δd::AbstractA
     itskip = round(Int, kwargs[:dtrec]/kwargs[:dtmod])
     kwargs[:reportinterval] == 0 || @info "linear adjoint on $(gethostname()), srcfieldfile=$(kwargs[:srcfieldfile])"
     time1 = time()
-    cumtime_io, cumtime_ex, cumtime_im = 0.0, 0.0, 0.0
+    cumtime_io, cumtime_ex, cumtime_im, cumtime_pr = 0.0, 0.0, 0.0, 0.0
 
     set_zero_subnormals(true)
     for it = ntmod:-1:1
         if kwargs[:reportinterval] != 0 && (it % kwargs[:reportinterval] == 0 || it == ntmod)
-            JopProp2DAcoTTIDenQ_DEO2_FDTD_write_history_ln(kwargs[:ginsu], it, ntmod, time()-time1, cumtime_io, cumtime_ex, cumtime_im, pcur, δdinterp, "adjoint")
+            JopProp2DAcoTTIDenQ_DEO2_FDTD_write_history_ln(kwargs[:ginsu], it, ntmod, time()-time1, cumtime_io, cumtime_ex, cumtime_im, cumtime_pr, pcur, δdinterp, "adjoint")
         end
 
         # propagate and wavefield swap
-        WaveFD.propagateadjoint!(p)
+        cumtime_pr += @elapsed WaveFD.propagateadjoint!(p)
         pcur,pold = pold,pcur
 
         # inject receiver data
@@ -855,24 +855,26 @@ end
 
 Jets.perfstat(J::T) where {D,R,T<:Jet{D,R,typeof(JopProp2DAcoTTIDenQ_DEO2_FDTD_f!)}} = state(J).stats
 
-@inline function JopProp2DAcoTTIDenQ_DEO2_FDTD_write_history_ln(ginsu, it, ntmod, cumtime_total, cumtime_io, cumtime_ex, cumtime_im, pcur, d::AbstractArray{T}, mode) where {T}
+@inline function JopProp2DAcoTTIDenQ_DEO2_FDTD_write_history_ln(ginsu, it, ntmod, cumtime_total, cumtime_io, cumtime_ex, cumtime_im, cumtime_pr, pcur, d::AbstractArray{T}, mode) where {T}
     itd = occursin("adjoint", mode) ? ntmod-it+1 : it
     rmsp = sqrt(norm(pcur)^2 / length(pcur))
     rmsd = d != nothing ? sqrt(norm(d)^2 / length(d)) : zero(T)
-    @info @sprintf("PropLn2DAcoTTIDenQ_DEO2_FDTD, %s, time step %5d of %5d ; %7.2f MCells/s (IO=%5.2f%%, EX=%5.2f%%, IM=%5.2f%%) -- rms d,p; %10.4e %10.4e", mode, itd, ntmod,
+    @info @sprintf("PropLn2DAcoTTIDenQ_DEO2_FDTD, %s, time step %5d of %5d ; %7.2f MCells/s (IO=%5.2f%%, EX=%5.2f%%, IM=%5.2f%%, PR=%5.2f%%) -- rms d,p; %10.4e %10.4e", mode, itd, ntmod,
                     megacells_per_second(size(ginsu)..., itd-1, cumtime_total),
                     cumtime_total > 0 ? cumtime_io/cumtime_total*100.0 : 0.0,
                     cumtime_total > 0 ? cumtime_ex/cumtime_total*100.0 : 0.0,
-                    cumtime_total > 0 ? cumtime_im/cumtime_total*100.0 : 0.0, rmsd, rmsp)
+                    cumtime_total > 0 ? cumtime_im/cumtime_total*100.0 : 0.0,
+                    cumtime_total > 0 ? cumtime_pr/cumtime_total*100.0 : 0.0,  rmsd, rmsp)
 end
 
-@inline function JopProp2DAcoTTIDenQ_DEO2_FDTD_write_history_nl(ginsu, it, ntmod, cumtime_total, cumtime_io, cumtime_ex, pcur, d::AbstractArray{T}) where {T}
+@inline function JopProp2DAcoTTIDenQ_DEO2_FDTD_write_history_nl(ginsu, it, ntmod, cumtime_total, cumtime_io, cumtime_ex, cumtime_pr, pcur, d::AbstractArray{T}) where {T}
     rmsp = sqrt(norm(pcur)^2 / length(pcur))
     rmsd = length(d) > 0 ? sqrt(norm(d)^2 / length(d)) : zero(T)
-    @info @sprintf("Prop2DAcoTTIDenQ_DEO2_FDTD, nonlinear forward, time step %5d of %5d ; %7.2f MCells/s (IO=%5.2f%%, EX=%5.2f%%) -- rms d,p; %10.4e %10.4e", it, ntmod,
+    @info @sprintf("Prop2DAcoTTIDenQ_DEO2_FDTD, nonlinear forward, time step %5d of %5d ; %7.2f MCells/s (IO=%5.2f%%, EX=%5.2f%%, PR=%5.2f%%) -- rms d,p; %10.4e %10.4e", it, ntmod,
                     megacells_per_second(size(ginsu)..., it-1, cumtime_total),
                     cumtime_total > 0 ? cumtime_io/cumtime_total*100.0 : 0.0,
-                    cumtime_total > 0 ? cumtime_ex/cumtime_total*100.0 : 0.0, rmsd, rmsp)
+                    cumtime_total > 0 ? cumtime_ex/cumtime_total*100.0 : 0.0,
+                    cumtime_total > 0 ? cumtime_pr/cumtime_total*100.0 : 0.0, rmsd, rmsp)
 end
 
 function Base.close(jet::Jet{D,R,typeof(JopProp2DAcoTTIDenQ_DEO2_FDTD_f!)}) where {D,R}

--- a/src/jop_prop2DAcoVTIDenQ_DEO2_FDTD.jl
+++ b/src/jop_prop2DAcoVTIDenQ_DEO2_FDTD.jl
@@ -489,17 +489,17 @@ function JopProp2DAcoVTIDenQ_DEO2_FDTD_nonlinearforward!(d::AbstractArray, m::Ab
 
     itskip = round(Int, kwargs[:dtrec]/kwargs[:dtmod])
     time1 = time()
-    cumtime_io, cumtime_ex = 0.0, 0.0
+    cumtime_io, cumtime_ex, cumtime_pr = 0.0, 0.0, 0.0
     kwargs[:reportinterval] == 0 || @info "nonlinear forward on $(gethostname()), srcfieldfile=$(kwargs[:srcfieldfile])"
 
     set_zero_subnormals(true)
     for it = 1:ntmod_wav
         if kwargs[:reportinterval] != 0 && (it % kwargs[:reportinterval] == 0 || it == ntmod_wav)
-            JopProp2DAcoVTIDenQ_DEO2_FDTD_write_history_nl(kwargs[:ginsu], it, ntmod_wav, time()-time1, cumtime_io, cumtime_ex, wavefields["pcur"], d)
+            JopProp2DAcoVTIDenQ_DEO2_FDTD_write_history_nl(kwargs[:ginsu], it, ntmod_wav, time()-time1, cumtime_io, cumtime_ex, cumtime_pr, wavefields["pcur"], d)
         end
 
         # propagate and wavefield swap
-        WaveFD.propagateforward!(p)
+        cumtime_pr += @elapsed WaveFD.propagateforward!(p)
         wavefields["pcur"],wavefields["pold"] = wavefields["pold"],wavefields["pcur"]
         wavefields["mcur"],wavefields["mold"] = wavefields["mold"],wavefields["mcur"]
 
@@ -512,7 +512,7 @@ function JopProp2DAcoVTIDenQ_DEO2_FDTD_nonlinearforward!(d::AbstractArray, m::Ab
         if it >= it0 && rem(it-1,itskip) == 0
             if length(d) > 0
                 # extract receiver data
-                WaveFD.extractdata!(d, wavefields["pold"], div(it-1,itskip)+1, iz_rec, ix_rec, c_rec)
+                cumtime_ex += @elapsed WaveFD.extractdata!(d, wavefields["pold"], div(it-1,itskip)+1, iz_rec, ix_rec, c_rec)
             end
 
             # scale spatial derivatives by v^2/b to make them temporal derivatives
@@ -650,17 +650,17 @@ function JopProp2DAcoVTIDenQ_DEO2_FDTD_df!(δd::AbstractArray, δm::AbstractArra
     itskip = round(Int, kwargs[:dtrec]/kwargs[:dtmod])
     kwargs[:reportinterval] == 0 || @info "linear forward on $(gethostname()), srcfieldfile=$(kwargs[:srcfieldfile])"
     time1 = time()
-    cumtime_io, cumtime_ex, cumtime_im = 0.0, 0.0, 0.0
+    cumtime_io, cumtime_ex, cumtime_im, cumtime_pr = 0.0, 0.0, 0.0, 0.0
 
     set_zero_subnormals(true)
     for it = 1:ntmod
         if kwargs[:reportinterval] != 0 && (it % kwargs[:reportinterval] == 0 || it == ntmod)
             JopProp2DAcoVTIDenQ_DEO2_FDTD_write_history_ln(kwargs[:ginsu], it, ntmod, time()-time1, 
-                cumtime_io, cumtime_ex, cumtime_im, pcur, δdinterp, "forward")
+                cumtime_io, cumtime_ex, cumtime_im, cumtime_pr, pcur, δdinterp, "forward")
         end
 
         # propagate and swap wavefields
-        WaveFD.propagateforward!(p)
+        cumtime_pr += @elapsed WaveFD.propagateforward!(p)
         pcur,pold = pold,pcur
 
         if rem(it-1,itskip) == 0
@@ -782,16 +782,16 @@ function JopProp2DAcoVTIDenQ_DEO2_FDTD_df′!(δm::AbstractArray, δd::AbstractA
     itskip = round(Int, kwargs[:dtrec]/kwargs[:dtmod])
     kwargs[:reportinterval] == 0 || @info "linear adjoint on $(gethostname()), srcfieldfile=$(kwargs[:srcfieldfile])"
     time1 = time()
-    cumtime_io, cumtime_ex, cumtime_im = 0.0, 0.0, 0.0
+    cumtime_io, cumtime_ex, cumtime_im, cumtime_pr = 0.0, 0.0, 0.0, 0.0
 
     set_zero_subnormals(true)
     for it = ntmod:-1:1
         if kwargs[:reportinterval] != 0 && (it % kwargs[:reportinterval] == 0 || it == ntmod)
-            JopProp2DAcoVTIDenQ_DEO2_FDTD_write_history_ln(kwargs[:ginsu], it, ntmod, time()-time1, cumtime_io, cumtime_ex, cumtime_im, pcur, δdinterp, "adjoint")
+            JopProp2DAcoVTIDenQ_DEO2_FDTD_write_history_ln(kwargs[:ginsu], it, ntmod, time()-time1, cumtime_io, cumtime_ex, cumtime_im, cumtime_pr, pcur, δdinterp, "adjoint")
         end
 
         # propagate and wavefield swap
-        WaveFD.propagateadjoint!(p)
+        cumtime_pr += @elapsed WaveFD.propagateadjoint!(p)
         pcur,pold = pold,pcur
 
         # inject receiver data
@@ -856,24 +856,26 @@ end
 
 Jets.perfstat(J::T) where {D,R,T<:Jet{D,R,typeof(JopProp2DAcoVTIDenQ_DEO2_FDTD_f!)}} = state(J).stats
 
-@inline function JopProp2DAcoVTIDenQ_DEO2_FDTD_write_history_ln(ginsu, it, ntmod, cumtime_total, cumtime_io, cumtime_ex, cumtime_im, pcur, d::AbstractArray{T}, mode) where {T}
+@inline function JopProp2DAcoVTIDenQ_DEO2_FDTD_write_history_ln(ginsu, it, ntmod, cumtime_total, cumtime_io, cumtime_ex, cumtime_im, cumtime_pr, pcur, d::AbstractArray{T}, mode) where {T}
     itd = occursin("adjoint", mode) ? ntmod-it+1 : it
     rmsp = sqrt(norm(pcur)^2 / length(pcur))
     rmsd = d != nothing ? sqrt(norm(d)^2 / length(d)) : zero(T)
-    @info @sprintf("PropLn2DAcoVTIDenQ_DEO2_FDTD, %s, time step %5d of %5d ; %7.2f MCells/s (IO=%5.2f%%, EX=%5.2f%%, IM=%5.2f%%) -- rms d,p; %10.4e %10.4e", mode, itd, ntmod,
+    @info @sprintf("PropLn2DAcoVTIDenQ_DEO2_FDTD, %s, time step %5d of %5d ; %7.2f MCells/s (IO=%5.2f%%, EX=%5.2f%%, IM=%5.2f%%, PR=%5.2f%%) -- rms d,p; %10.4e %10.4e", mode, itd, ntmod,
                     megacells_per_second(size(ginsu)..., itd-1, cumtime_total),
                     cumtime_total > 0 ? cumtime_io/cumtime_total*100.0 : 0.0,
                     cumtime_total > 0 ? cumtime_ex/cumtime_total*100.0 : 0.0,
-                    cumtime_total > 0 ? cumtime_im/cumtime_total*100.0 : 0.0, rmsd, rmsp)
+                    cumtime_total > 0 ? cumtime_im/cumtime_total*100.0 : 0.0,
+                    cumtime_total > 0 ? cumtime_pr/cumtime_total*100.0 : 0.0, rmsd, rmsp)
 end
 
-@inline function JopProp2DAcoVTIDenQ_DEO2_FDTD_write_history_nl(ginsu, it, ntmod, cumtime_total, cumtime_io, cumtime_ex, pcur, d::AbstractArray{T}) where {T}
+@inline function JopProp2DAcoVTIDenQ_DEO2_FDTD_write_history_nl(ginsu, it, ntmod, cumtime_total, cumtime_io, cumtime_ex, cumtime_pr, pcur, d::AbstractArray{T}) where {T}
     rmsp = sqrt(norm(pcur)^2 / length(pcur))
     rmsd = length(d) > 0 ? sqrt(norm(d)^2 / length(d)) : zero(T)
-    @info @sprintf("Prop2DAcoVTIDenQ_DEO2_FDTD, nonlinear forward, time step %5d of %5d ; %7.2f MCells/s (IO=%5.2f%%, EX=%5.2f%%) -- rms d,p; %10.4e %10.4e", it, ntmod,
+    @info @sprintf("Prop2DAcoVTIDenQ_DEO2_FDTD, nonlinear forward, time step %5d of %5d ; %7.2f MCells/s (IO=%5.2f%%, EX=%5.2f%%, PR=%5.2f%%) -- rms d,p; %10.4e %10.4e", it, ntmod,
                     megacells_per_second(size(ginsu)..., it-1, cumtime_total),
                     cumtime_total > 0 ? cumtime_io/cumtime_total*100.0 : 0.0,
-                    cumtime_total > 0 ? cumtime_ex/cumtime_total*100.0 : 0.0, rmsd, rmsp)
+                    cumtime_total > 0 ? cumtime_ex/cumtime_total*100.0 : 0.0,
+                    cumtime_total > 0 ? cumtime_pr/cumtime_total*100.0 : 0.0, rmsd, rmsp)
 end
 
 function Base.close(jet::Jet{D,R,typeof(JopProp2DAcoVTIDenQ_DEO2_FDTD_f!)}) where {D,R}

--- a/src/jop_prop3DAcoIsoDenQ_DEO2_FDTD.jl
+++ b/src/jop_prop3DAcoIsoDenQ_DEO2_FDTD.jl
@@ -410,17 +410,17 @@ function JopProp3DAcoIsoDenQ_DEO2_FDTD_nonlinearforward!(d::AbstractArray, m::Ab
 
     itskip = round(Int, kwargs[:dtrec]/kwargs[:dtmod])
     time1 = time()
-    cumtime_io, cumtime_ex = 0.0, 0.0
+    cumtime_io, cumtime_ex, cumtime_pr = 0.0, 0.0, 0.0
     kwargs[:reportinterval] == 0 || @info "nonlinear forward on $(gethostname()), srcfieldfile=$(kwargs[:srcfieldfile])"
 
     set_zero_subnormals(true)
     for it = 1:ntmod_wav
         if kwargs[:reportinterval] != 0 && (it % kwargs[:reportinterval] == 0 || it == ntmod_wav)
-            JopProp3DAcoIsoDenQ_DEO2_FDTD_write_history_nl(kwargs[:ginsu], it, ntmod_wav, time()-time1, cumtime_io, cumtime_ex, pcur, d)
+            JopProp3DAcoIsoDenQ_DEO2_FDTD_write_history_nl(kwargs[:ginsu], it, ntmod_wav, time()-time1, cumtime_io, cumtime_ex, cumtime_pr, pcur, d)
         end
 
         # propagate and wavefield swap
-        WaveFD.propagateforward!(p)
+        cumtime_pr += @elapsed WaveFD.propagateforward!(p)
         pcur,pold = pold,pcur
 
         # inject source wavelet
@@ -432,7 +432,7 @@ function JopProp3DAcoIsoDenQ_DEO2_FDTD_nonlinearforward!(d::AbstractArray, m::Ab
         if it >= it0 && rem(it-1,itskip) == 0
             if length(d) > 0
                 # extract receiver data
-                WaveFD.extractdata!(d, pold, div(it-1,itskip)+1, iz_rec, iy_rec, ix_rec, c_rec)
+                cumtime_ex += @elapsed WaveFD.extractdata!(d, pold, div(it-1,itskip)+1, iz_rec, iy_rec, ix_rec, c_rec)
             end
 
             # scale spatial derivatives by v^2/b to make them temporal derivatives
@@ -557,16 +557,16 @@ function JopProp3DAcoIsoDenQ_DEO2_FDTD_df!(δd::AbstractArray, δm::AbstractArra
     itskip = round(Int, kwargs[:dtrec]/kwargs[:dtmod])
     kwargs[:reportinterval] == 0 || @info "linear forward on $(gethostname()), srcfieldfile=$(kwargs[:srcfieldfile])"
     time1 = time()
-    cumtime_io, cumtime_ex, cumtime_im = 0.0, 0.0, 0.0
+    cumtime_io, cumtime_ex, cumtime_im, cumtime_pr = 0.0, 0.0, 0.0, 0.0
 
     set_zero_subnormals(true)
     for it = 1:ntmod
         if kwargs[:reportinterval] != 0 && (it % kwargs[:reportinterval] == 0 || it == ntmod)
-            JopProp3DAcoIsoDenQ_DEO2_FDTD_write_history_ln(kwargs[:ginsu], it, ntmod, time()-time1, cumtime_io, cumtime_ex, cumtime_im, pcur, δdinterp, "forward")
+            JopProp3DAcoIsoDenQ_DEO2_FDTD_write_history_ln(kwargs[:ginsu], it, ntmod, time()-time1, cumtime_io, cumtime_ex, cumtime_im, cumtime_pr, pcur, δdinterp, "forward")
         end
 
         # propagate and swap wavefields
-        WaveFD.propagateforward!(p)
+        cumtime_pr += @elapsed WaveFD.propagateforward!(p)
         pcur,pold = pold,pcur
 
         if rem(it-1,itskip) == 0
@@ -669,16 +669,16 @@ function JopProp3DAcoIsoDenQ_DEO2_FDTD_df′!(δm::AbstractArray, δd::AbstractA
     itskip = round(Int, kwargs[:dtrec]/kwargs[:dtmod])
     kwargs[:reportinterval] == 0 || @info "linear adjoint on $(gethostname()), srcfieldfile=$(kwargs[:srcfieldfile])"
     time1 = time()
-    cumtime_io, cumtime_ex, cumtime_im = 0.0, 0.0, 0.0
+    cumtime_io, cumtime_ex, cumtime_im, cumtime_pr = 0.0, 0.0, 0.0, 0.0
 
     set_zero_subnormals(true)
     for it = ntmod:-1:1
         if kwargs[:reportinterval] != 0 && (it % kwargs[:reportinterval] == 0 || it == ntmod)
-            JopProp3DAcoIsoDenQ_DEO2_FDTD_write_history_ln(kwargs[:ginsu], it, ntmod, time()-time1, cumtime_io, cumtime_ex, cumtime_im, pcur, δdinterp, "adjoint")
+            JopProp3DAcoIsoDenQ_DEO2_FDTD_write_history_ln(kwargs[:ginsu], it, ntmod, time()-time1, cumtime_io, cumtime_ex, cumtime_im, cumtime_pr, pcur, δdinterp, "adjoint")
         end
 
         # propagate and wavefield swap
-        WaveFD.propagateadjoint!(p)
+        cumtime_pr += @elapsed WaveFD.propagateadjoint!(p)
         pcur,pold = pold,pcur
 
         # inject receiver data
@@ -733,24 +733,26 @@ end
 
 Jets.perfstat(J::T) where {D,R,T<:Jet{D,R,typeof(JopProp3DAcoIsoDenQ_DEO2_FDTD_f!)}} = state(J).stats
 
-@inline function JopProp3DAcoIsoDenQ_DEO2_FDTD_write_history_ln(ginsu, it, ntmod, cumtime_total, cumtime_io, cumtime_ex, cumtime_im, pcur, d::AbstractArray{T}, mode) where {T}
+@inline function JopProp3DAcoIsoDenQ_DEO2_FDTD_write_history_ln(ginsu, it, ntmod, cumtime_total, cumtime_io, cumtime_ex, cumtime_im, cumtime_pr, pcur, d::AbstractArray{T}, mode) where {T}
     itd = occursin("adjoint", mode) ? ntmod-it+1 : it
     rmsp = sqrt(norm(pcur)^2 / length(pcur))
     rmsd = d != nothing ? sqrt(norm(d)^2 / length(d)) : zero(T)
-    @info @sprintf("PropLn3DAcoIsoDenQ_DEO2_FDTD, %s, time step %5d of %5d ; %7.2f MCells/s (IO=%5.2f%%, EX=%5.2f%%, IM=%5.2f%%) -- rms d,p; %10.4e %10.4e", mode, itd, ntmod,
+    @info @sprintf("PropLn3DAcoIsoDenQ_DEO2_FDTD, %s, time step %5d of %5d ; %7.2f MCells/s (IO=%5.2f%%, EX=%5.2f%%, IM=%5.2f%%, PR=%5.2f%%) -- rms d,p; %10.4e %10.4e", mode, itd, ntmod,
                     megacells_per_second(size(ginsu)..., itd-1, cumtime_total),
                     cumtime_total > 0 ? cumtime_io/cumtime_total*100.0 : 0.0,
                     cumtime_total > 0 ? cumtime_ex/cumtime_total*100.0 : 0.0,
-                    cumtime_total > 0 ? cumtime_im/cumtime_total*100.0 : 0.0, rmsd, rmsp)
+                    cumtime_total > 0 ? cumtime_im/cumtime_total*100.0 : 0.0,
+                    cumtime_total > 0 ? cumtime_pr/cumtime_total*100.0 : 0.0, rmsd, rmsp)
 end
 
-@inline function JopProp3DAcoIsoDenQ_DEO2_FDTD_write_history_nl(ginsu, it, ntmod, cumtime_total, cumtime_io, cumtime_ex, pcur, d::AbstractArray{T}) where {T}
+@inline function JopProp3DAcoIsoDenQ_DEO2_FDTD_write_history_nl(ginsu, it, ntmod, cumtime_total, cumtime_io, cumtime_ex, cumtime_pr, pcur, d::AbstractArray{T}) where {T}
     rmsp = sqrt(norm(pcur)^2 / length(pcur))
     rmsd = length(d) > 0 ? sqrt(norm(d)^2 / length(d)) : zero(T)
-    @info @sprintf("Prop3DAcoIsoDenQ_DEO2_FDTD, nonlinear forward, time step %5d of %5d ; %7.2f MCells/s (IO=%5.2f%%, EX=%5.2f%%) -- rms d,p; %10.4e %10.4e", it, ntmod,
+    @info @sprintf("Prop3DAcoIsoDenQ_DEO2_FDTD, nonlinear forward, time step %5d of %5d ; %7.2f MCells/s (IO=%5.2f%%, EX=%5.2f%%, PR=%5.2f%%) -- rms d,p; %10.4e %10.4e", it, ntmod,
                     megacells_per_second(size(ginsu)..., it-1, cumtime_total),
                     cumtime_total > 0 ? cumtime_io/cumtime_total*100.0 : 0.0,
-                    cumtime_total > 0 ? cumtime_ex/cumtime_total*100.0 : 0.0, rmsd, rmsp)
+                    cumtime_total > 0 ? cumtime_ex/cumtime_total*100.0 : 0.0,
+                    cumtime_total > 0 ? cumtime_pr/cumtime_total*100.0 : 0.0, rmsd, rmsp)
 end
 
 function Base.close(j::Jet{D,R,typeof(JopProp3DAcoIsoDenQ_DEO2_FDTD_f!)}) where {D,R}

--- a/src/jop_prop3DAcoVTIDenQ_DEO2_FDTD.jl
+++ b/src/jop_prop3DAcoVTIDenQ_DEO2_FDTD.jl
@@ -515,17 +515,17 @@ function JopProp3DAcoVTIDenQ_DEO2_FDTD_nonlinearforward!(d::AbstractArray, m::Ab
 
     itskip = round(Int, kwargs[:dtrec]/kwargs[:dtmod])
     time1 = time()
-    cumtime_io, cumtime_ex = 0.0, 0.0
+    cumtime_io, cumtime_ex, cumtime_pr = 0.0, 0.0, 0.0
     kwargs[:reportinterval] == 0 || @info "nonlinear forward on $(gethostname()), srcfieldfile=$(kwargs[:srcfieldfile])"
 
     set_zero_subnormals(true)
     for it = 1:ntmod_wav
         if kwargs[:reportinterval] != 0 && (it % kwargs[:reportinterval] == 0 || it == ntmod_wav)
-            JopProp3DAcoVTIDenQ_DEO2_FDTD_write_history_nl(kwargs[:ginsu], it, ntmod_wav, time()-time1, cumtime_io, cumtime_ex, wavefields["pcur"], d)
+            JopProp3DAcoVTIDenQ_DEO2_FDTD_write_history_nl(kwargs[:ginsu], it, ntmod_wav, time()-time1, cumtime_io, cumtime_ex, cumtime_pr, wavefields["pcur"], d)
         end
 
         # propagate and wavefield swap
-        WaveFD.propagateforward!(p)
+        cumtime_pr += @elapsed WaveFD.propagateforward!(p)
         wavefields["pcur"],wavefields["pold"] = wavefields["pold"],wavefields["pcur"]
         wavefields["mcur"],wavefields["mold"] = wavefields["mold"],wavefields["mcur"]
 
@@ -538,7 +538,7 @@ function JopProp3DAcoVTIDenQ_DEO2_FDTD_nonlinearforward!(d::AbstractArray, m::Ab
         if it >= it0 && rem(it-1,itskip) == 0
             if length(d) > 0
                 # extract receiver data
-                WaveFD.extractdata!(d, wavefields["pold"], div(it-1,itskip)+1, iz_rec, iy_rec, ix_rec, c_rec)
+                cumtime_ex += @elapsed WaveFD.extractdata!(d, wavefields["pold"], div(it-1,itskip)+1, iz_rec, iy_rec, ix_rec, c_rec)
             end
 
             # scale spatial derivatives by v^2/b to make them temporal derivatives
@@ -679,17 +679,17 @@ function JopProp3DAcoVTIDenQ_DEO2_FDTD_df!(δd::AbstractArray, δm::AbstractArra
     itskip = round(Int, kwargs[:dtrec]/kwargs[:dtmod])
     kwargs[:reportinterval] == 0 || @info "linear forward on $(gethostname()), srcfieldfile=$(kwargs[:srcfieldfile])"
     time1 = time()
-    cumtime_io, cumtime_ex, cumtime_im = 0.0, 0.0, 0.0
+    cumtime_io, cumtime_ex, cumtime_im, cumtime_pr = 0.0, 0.0, 0.0, 0.0
 
     set_zero_subnormals(true)
     for it = 1:ntmod
         if kwargs[:reportinterval] != 0 && (it % kwargs[:reportinterval] == 0 || it == ntmod)
             JopProp3DAcoVTIDenQ_DEO2_FDTD_write_history_ln(kwargs[:ginsu], it, ntmod, time()-time1, 
-                cumtime_io, cumtime_ex, cumtime_im, pcur, δdinterp, "forward")
+                cumtime_io, cumtime_ex, cumtime_im, cumtime_pr, pcur, δdinterp, "forward")
         end
 
         # propagate and swap wavefields
-        WaveFD.propagateforward!(p)
+        cumtime_pr += @elapsed WaveFD.propagateforward!(p)
         pcur,pold = pold,pcur
 
         if rem(it-1,itskip) == 0
@@ -817,16 +817,16 @@ function JopProp3DAcoVTIDenQ_DEO2_FDTD_df′!(δm::AbstractArray, δd::AbstractA
     itskip = round(Int, kwargs[:dtrec]/kwargs[:dtmod])
     kwargs[:reportinterval] == 0 || @info "linear adjoint on $(gethostname()), srcfieldfile=$(kwargs[:srcfieldfile])"
     time1 = time()
-    cumtime_io, cumtime_ex, cumtime_im = 0.0, 0.0, 0.0
+    cumtime_io, cumtime_ex, cumtime_im, cumtime_pr = 0.0, 0.0, 0.0, 0.0
 
     set_zero_subnormals(true)
     for it = ntmod:-1:1
         if kwargs[:reportinterval] != 0 && (it % kwargs[:reportinterval] == 0 || it == ntmod)
-            JopProp3DAcoVTIDenQ_DEO2_FDTD_write_history_ln(kwargs[:ginsu], it, ntmod, time()-time1, cumtime_io, cumtime_ex, cumtime_im, pcur, δdinterp, "adjoint")
+            JopProp3DAcoVTIDenQ_DEO2_FDTD_write_history_ln(kwargs[:ginsu], it, ntmod, time()-time1, cumtime_io, cumtime_ex, cumtime_im, cumtime_pr, pcur, δdinterp, "adjoint")
         end
 
         # propagate and wavefield swap
-        WaveFD.propagateadjoint!(p)
+        cumtime_pr += @elapsed WaveFD.propagateadjoint!(p)
         pcur,pold = pold,pcur
 
         # inject receiver data
@@ -891,24 +891,26 @@ end
 
 Jets.perfstat(J::T) where {D,R,T<:Jet{D,R,typeof(JopProp3DAcoVTIDenQ_DEO2_FDTD_f!)}} = state(J).stats
 
-@inline function JopProp3DAcoVTIDenQ_DEO2_FDTD_write_history_ln(ginsu, it, ntmod, cumtime_total, cumtime_io, cumtime_ex, cumtime_im, pcur, d::AbstractArray{T}, mode) where {T}
+@inline function JopProp3DAcoVTIDenQ_DEO2_FDTD_write_history_ln(ginsu, it, ntmod, cumtime_total, cumtime_io, cumtime_ex, cumtime_im, cumtime_pr, pcur, d::AbstractArray{T}, mode) where {T}
     itd = occursin("adjoint", mode) ? ntmod-it+1 : it
     rmsp = sqrt(norm(pcur)^2 / length(pcur))
     rmsd = d != nothing ? sqrt(norm(d)^2 / length(d)) : zero(T)
-    @info @sprintf("PropLn3DAcoVTIDenQ_DEO2_FDTD, %s, time step %5d of %5d ; %7.2f MCells/s (IO=%5.2f%%, EX=%5.2f%%, IM=%5.2f%%) -- rms d,p; %10.4e %10.4e", mode, itd, ntmod,
+    @info @sprintf("PropLn3DAcoVTIDenQ_DEO2_FDTD, %s, time step %5d of %5d ; %7.2f MCells/s (IO=%5.2f%%, EX=%5.2f%%, IM=%5.2f%%, PR=%5.2f%%) -- rms d,p; %10.4e %10.4e", mode, itd, ntmod,
                     megacells_per_second(size(ginsu)..., itd-1, cumtime_total),
                     cumtime_total > 0 ? cumtime_io/cumtime_total*100.0 : 0.0,
                     cumtime_total > 0 ? cumtime_ex/cumtime_total*100.0 : 0.0,
-                    cumtime_total > 0 ? cumtime_im/cumtime_total*100.0 : 0.0, rmsd, rmsp)
+                    cumtime_total > 0 ? cumtime_im/cumtime_total*100.0 : 0.0,
+                    cumtime_total > 0 ? cumtime_pr/cumtime_total*100.0 : 0.0, rmsd, rmsp)
 end
 
-@inline function JopProp3DAcoVTIDenQ_DEO2_FDTD_write_history_nl(ginsu, it, ntmod, cumtime_total, cumtime_io, cumtime_ex, pcur, d::AbstractArray{T}) where {T}
+@inline function JopProp3DAcoVTIDenQ_DEO2_FDTD_write_history_nl(ginsu, it, ntmod, cumtime_total, cumtime_io, cumtime_ex, cumtime_pr, pcur, d::AbstractArray{T}) where {T}
     rmsp = sqrt(norm(pcur)^2 / length(pcur))
     rmsd = length(d) > 0 ? sqrt(norm(d)^2 / length(d)) : zero(T)
-    @info @sprintf("Prop3DAcoVTIDenQ_DEO2_FDTD, nonlinear forward, time step %5d of %5d ; %7.2f MCells/s (IO=%5.2f%%, EX=%5.2f%%) -- rms d,p; %10.4e %10.4e", it, ntmod,
+    @info @sprintf("Prop3DAcoVTIDenQ_DEO2_FDTD, nonlinear forward, time step %5d of %5d ; %7.2f MCells/s (IO=%5.2f%%, EX=%5.2f%%, PR=%5.2f%%) -- rms d,p; %10.4e %10.4e", it, ntmod,
                     megacells_per_second(size(ginsu)..., it-1, cumtime_total),
                     cumtime_total > 0 ? cumtime_io/cumtime_total*100.0 : 0.0,
-                    cumtime_total > 0 ? cumtime_ex/cumtime_total*100.0 : 0.0, rmsd, rmsp)
+                    cumtime_total > 0 ? cumtime_ex/cumtime_total*100.0 : 0.0,
+                    cumtime_total > 0 ? cumtime_pr/cumtime_total*100.0 : 0.0, rmsd, rmsp)
 end
 
 function Base.close(j::Jet{D,R,typeof(JopProp3DAcoVTIDenQ_DEO2_FDTD_f!)}) where {D,R}


### PR DESCRIPTION
 In particular, there was a mistake in the timing information for wavefield extraction at the receivers.  In addition, I added timers for the actual propagation; where-as, before we just assumed that propagation was whatever remained.