### PR TITLE
Add density inversion capabilities to isotropic 2D and 3D operators #29

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -22,7 +22,7 @@ Formatting = "0.4"
 JetPack = "1"
 Jets = "1"
 SpecialFunctions = "0.10"
-WaveFD = "0.3"
+WaveFD = "0.4"
 julia = "1"
 
 [extras]

--- a/test/jop_prop2DAcoIsoDenQ_DEO2_FDTD.jl
+++ b/test/jop_prop2DAcoIsoDenQ_DEO2_FDTD.jl
@@ -1,6 +1,8 @@
 using Formatting, FFTW, Jets, JetPackWaveFD, LinearAlgebra, SpecialFunctions, Statistics, Test, WaveFD
 
-function make_op(interpmethod, fs; comptype = Float32)
+modeltypes = (WaveFD.Prop2DAcoIsoDenQ_DEO2_FDTD_Model_V, WaveFD.Prop2DAcoIsoDenQ_DEO2_FDTD_Model_B, WaveFD.Prop2DAcoIsoDenQ_DEO2_FDTD_Model_VB)
+
+function make_op(interpmethod, modeltype, fs; comptype = Float32)
     nsponge = 10
     pad = 20
     nx = 60+2*pad
@@ -19,35 +21,49 @@ function make_op(interpmethod, fs; comptype = Float32)
     b = ones(Float32,nz,nx)
     v = 1500 .* ones(Float32,nz,nx)
 
-    F = JopNlProp2DAcoIsoDenQ_DEO2_FDTD(b = b, 
-        sx = sx, sz = sz, rx = rx, rz = rz, dx = dx, dz = dz, z0 = zmin, x0 = xmin, 
+    local m
+    if modeltype == WaveFD.Prop2DAcoIsoDenQ_DEO2_FDTD_Model_V
+        kwargs = (b = b, )
+        m = reshape(v, nz, nx, 1)
+    elseif modeltype == WaveFD.Prop2DAcoIsoDenQ_DEO2_FDTD_Model_VB
+        kwargs = (nz = nz, nx = nx)
+        m = zeros(Float32, nz, nx, 2)
+        m[:,:,1] .= v
+        m[:,:,2] .= b
+    elseif modeltype == WaveFD.Prop2DAcoIsoDenQ_DEO2_FDTD_Model_B
+        kwargs = (v = v, )
+        m = reshape(b, nz, nx, 1)
+    end
+
+    F = JopNlProp2DAcoIsoDenQ_DEO2_FDTD(; kwargs...,
+        z0 = zmin, x0 = xmin, dx = dx, dz = dz, sx = sx, sz = sz, rx = rx, rz = rz,
         dtrec = dt, dtmod = dt, ntrec = nt, nsponge = nsponge, comptype = comptype, compscale = 1e-4,
         freqQ = 5.0, qMin = 0.1, qInterior = 100.0, wavelet = wavelet, freesurface = fs, 
         reportinterval = 0, interpmethod = interpmethod, isinterior = false)
 
-    v,F
+    m,F
 end
 
-@testset "JopProp2DAcoIsoDenQ_DEO2_FDTD -- close" begin
-    m₀, F = make_op(:hicks, false)
+@testset "JopProp2DAcoIsoDenQ_DEO2_FDTD -- close, modeltype=$modeltype" for modeltype in modeltypes
+    m₀, F = make_op(:hicks, modeltype, false)
     d = F * m₀
-    @test isfile(state(F).srcfieldfile*"-P")
-    @test isfile(state(F).srcfieldfile*"-DP")
+    @test isfile(state(F).srcfieldfile*"-pold")
+    @test isfile(state(F).srcfieldfile*"-pspace")
     close(F)
-    @test !(isfile(state(F).srcfieldfile*"-P"))
-    @test !(isfile(state(F).srcfieldfile*"-DP"))
+    @test !(isfile(state(F).srcfieldfile*"-pold"))
+    @test !(isfile(state(F).srcfieldfile*"-pspace"))
     d = F * m₀
-    @test isfile(state(F).srcfieldfile*"-P")
-    @test isfile(state(F).srcfieldfile*"-DP")
+    @test isfile(state(F).srcfieldfile*"-pold")
+    @test isfile(state(F).srcfieldfile*"-pspace")
     close(F)
-    @test !(isfile(state(F).srcfieldfile*"-P"))
-    @test !(isfile(state(F).srcfieldfile*"-DP"))
+    @test !(isfile(state(F).srcfieldfile*"-pold"))
+    @test !(isfile(state(F).srcfieldfile*"-p"))
 
     close(F)
 end
 
-@testset "JopProp2DAcoIsoDenQ_DEO2_FDTD -- perfstat" begin
-    m₀, F = make_op(:hicks, false)
+@testset "JopProp2DAcoIsoDenQ_DEO2_FDTD -- perfstat, modeltype=$modeltype" for modeltype in modeltypes
+    m₀, F = make_op(:hicks, modeltype, false)
     
     s = Jets.perfstat(F)
     @test isa(s["MCells/s"], Float64)
@@ -73,11 +89,21 @@ end
     close(F)
 end
 
-@testset "JopProp2DAcoIsoDenQ_DEO2_FDTD -- linearization, interpmethod=$interpmethod, fs=$fs" for interpmethod in (:hicks,:linear), fs in (false,true)
-    m₀, F = make_op(interpmethod, fs)
+@testset "JopProp2DAcoIsoDenQ_DEO2_FDTD -- linearization, interpmethod=$interpmethod, fs=$fs, modeltype=$modeltype" for interpmethod in (:linear,), fs in (false,), modeltype in modeltypes
+    mₒ, F = make_op(interpmethod, modeltype, fs)
 
-    μobs, μexp = linearization_test(F,m₀,
-        μ = 100*sqrt.([1.0,1.0/2.0,1.0/4.0,1.0/8.0,1.0/16.0,1.0/32.0,1.0/64.0,1.0/128.0,1.0/256.0,1.0/512.0]))
+    δm = -1 .+ 2 .* rand(domain(F))
+    if modeltype == WaveFD.Prop2DAcoIsoDenQ_DEO2_FDTD_Model_V
+        δm[:,:,1] .*= 50
+    elseif modeltype == WaveFD.Prop2DAcoIsoDenQ_DEO2_FDTD_Model_VB
+        δm[:,:,1] .*= 50
+        δm[:,:,2] .*= 0.1
+    elseif modeltype == WaveFD.Prop2DAcoIsoDenQ_DEO2_FDTD_Model_B
+        δm[:,:,1] .*= 0.1
+    end
+
+    μobs, μexp = linearization_test(F, mₒ, δm = δm,
+        μ = sqrt.([1.0,1.0/2.0,1.0/4.0,1.0/8.0,1.0/16.0,1.0/32.0,1.0/64.0,1.0/128.0,1.0/256.0,1.0/512.0]))
 
     @show μobs, μexp
     @show minimum(abs, μobs - μexp)
@@ -86,8 +112,19 @@ end
     close(F)
 end
 
-@testset "JopProp2DAcoIsoDenQ_DEO2_FDTD -- dot product, interpmethod=$interpmethod, fs=$fs" for interpmethod in (:hicks,:linear), fs in (true,false)
-    m₀, F = make_op(interpmethod, fs)
+@testset "JopProp2DAcoIsoDenQ_DEO2_FDTD -- dot product, interpmethod=$interpmethod, fs=$fs, modeltype=$modeltype" for interpmethod in (:hicks,:linear), fs in (true,false), modeltype in modeltypes
+    m₀, F = make_op(interpmethod, modeltype, fs)
+
+    m = -1 .+ 2 .* rand(domain(F))
+    if modeltype == WaveFD.Prop2DAcoIsoDenQ_DEO2_FDTD_Model_V
+        m[:,:,1] .*= 50
+    elseif modeltype == WaveFD.Prop2DAcoIsoDenQ_DEO2_FDTD_Model_VB
+        m[:,:,1] .*= 50
+        m[:,:,2] .*= 0.1
+    elseif modeltype == WaveFD.Prop2DAcoIsoDenQ_DEO2_FDTD_Model_B
+        m[:,:,1] .*= 0.1
+    end
+
     J = jacobian!(F, m₀)
     m = -1 .+ 2*rand(domain(J))
     d = -1 .+ 2*rand(range(J))
@@ -101,9 +138,9 @@ end
     close(F)
 end
 
-@testset "JopProp2DAcoIsoDenQ_DEO2_FDTD -- linearity, interpmethod=$interpmethod, fs=$fs" for interpmethod in (:linear,:hicks), fs in (true,false)
-    m₀, F = make_op(interpmethod, fs)
-    J = jacobian!(F, m₀) 
+@testset "JopProp2DAcoIsoDenQ_DEO2_FDTD -- linearity, interpmethod=$interpmethod, fs=$fs, modeltype=$modeltype" for interpmethod in (:linear,:hicks), fs in (true,false), modeltype in modeltypes
+    m₀, F = make_op(interpmethod, modeltype, fs)
+    J = jacobian!(F, m₀)
     lhs,rhs = linearity_test(J)
     @test lhs ≈ rhs
 
@@ -111,8 +148,8 @@ end
 end
 
 # note the compression is exercised on the second pass of F * m₀
-@testset "JopProp2DAcoIsoDenQ_DEO2_FDTD -- serialization, C=$C" for C in (Float32, UInt32)
-    m₀, F = make_op(:hicks, false, comptype = C)
+@testset "JopProp2DAcoIsoDenQ_DEO2_FDTD -- serialization, C=$C, modeltype=$modeltype" for C in (Float32, UInt32), modeltype in modeltypes
+    m₀, F = make_op(:hicks, modeltype, false, comptype = C)
     d₁ = F * m₀
     d₂ = F * m₀
     @test d₁ ≈ d₂


### PR DESCRIPTION
2D and 3D isotropic complete. images below show linearized forward, might generate similar for linearized adjoint.

edit: note tests will fail until we get the bumped `WaveFD` and `WaveFD_jll` from `yggdrasil`.

## 2D
### 2D model for velocity (top) and buoyancy (bottom)
![figure 2D model](https://user-images.githubusercontent.com/45494770/113454269-78d90780-93cd-11eb-8f6e-30a34c72314d.png)

### 2D nonlinear data
![figure 2D data nonlinear](https://user-images.githubusercontent.com/45494770/113454275-7bd3f800-93cd-11eb-9cd5-5a8c1b00acd4.png)

### 2D difference: nonlinear - background
![figure 2D data difference](https://user-images.githubusercontent.com/45494770/113454283-81314280-93cd-11eb-8293-478ed8f4e946.png)

### 2D linear data
![figure 2D data linear](https://user-images.githubusercontent.com/45494770/113454288-82fb0600-93cd-11eb-9fcb-32c59d6e544a.png)

## 3D
### 3D model for velocity (top) and buoyancy (bottom)
![figure 3D model](https://user-images.githubusercontent.com/45494770/113454398-c5244780-93cd-11eb-928c-c212d24dbcd6.png)

### 3D nonlinear data
![figure 3D data nonlinear](https://user-images.githubusercontent.com/45494770/113454402-c6ee0b00-93cd-11eb-9180-6f3d7ee34631.png)

### 3D difference: nonlinear - background
![figure 3D data difference](https://user-images.githubusercontent.com/45494770/113454413-ce151900-93cd-11eb-86bc-5a6b47ced5de.png)

### 3D linear data
![figure 3D data linear](https://user-images.githubusercontent.com/45494770/113454426-d40afa00-93cd-11eb-8252-780d184a4e13.png)
