### PR TITLE
Make array dimensions consistent

### DIFF
--- a/test/jop_prop2DAcoTTIDenQ_DEO2_FDTD.jl
+++ b/test/jop_prop2DAcoTTIDenQ_DEO2_FDTD.jl
@@ -22,12 +22,12 @@ function make_op(modeltype, interpmethod, fs; v₀=1500, ϵ₀=0.2, η₀=0.4, c
         ϵ = zeros(Float32,nz,nx)
         η = zeros(Float32,nz,nx)
     else
-        ϵ = Float32[]
-        η = Float32[]
+        ϵ = Array{Float32}(undef, 0, 0)
+        η = Array{Float32}(undef, 0, 0)
     end
 
     b = ones(Float32,nz,nx)
-    θ = (π/8) .* ones(Float32,nz,nx)
+    θ = (Float32(π)/8) .* ones(Float32,nz,nx)
 
     F = JopNlProp2DAcoTTIDenQ_DEO2_FDTD(b = b, f = 0.85, ϵ = ϵ, η = η, θ = θ, 
         z0 = zmin, x0 = xmin, dz = dz, dx = dx, 

--- a/test/jop_prop2DAcoVTIDenQ_DEO2_FDTD.jl
+++ b/test/jop_prop2DAcoVTIDenQ_DEO2_FDTD.jl
@@ -22,8 +22,8 @@ function make_op(modeltype, interpmethod, fs; v₀=1500, ϵ₀=0.2, η₀=0.4, c
         ϵ = zeros(Float32,nz,nx)
         η = zeros(Float32,nz,nx)
     else
-        ϵ = Float32[]
-        η = Float32[]
+        ϵ = Array{Float32}(undef,0,0)
+        η = Array{Float32}(undef,0,0)
     end
 
     b = ones(Float32,nz,nx)

--- a/test/jop_prop3DAcoTTIDenQ_DEO2_FDTD.jl
+++ b/test/jop_prop3DAcoTTIDenQ_DEO2_FDTD.jl
@@ -24,13 +24,13 @@ function make_op(modeltype, interpmethod, fs; v₀=1500, ϵ₀=0.2, η₀=0.4, c
         ϵ = zeros(Float32,nz,ny,nx)
         η = zeros(Float32,nz,ny,nx)
     else
-        ϵ = Float32[]
-        η = Float32[]
+        ϵ = Array{Float32}(undef,0,0,0)
+        η = Array{Float32}(undef,0,0,0)
     end
     
     b = ones(Float32,nz,ny,nx)
-    θ = (π/8) .* ones(Float32,nz,ny,nx)
-    ϕ = (π/4) .* ones(Float32,nz,ny,nx)
+    θ = (Float32(π)/8) .* ones(Float32,nz,ny,nx)
+    ϕ = (Float32(π)/4) .* ones(Float32,nz,ny,nx)
 
     F = JopNlProp3DAcoTTIDenQ_DEO2_FDTD(b = b, f = 0.85, ϵ = ϵ, η = η, θ = θ, ϕ = ϕ, 
         z0 = zmin, y0 = ymin, x0 = xmin, dz = dz, dy = dy, dx = dx, 

--- a/test/jop_prop3DAcoVTIDenQ_DEO2_FDTD.jl
+++ b/test/jop_prop3DAcoVTIDenQ_DEO2_FDTD.jl
@@ -24,8 +24,8 @@ function make_op(modeltype, interpmethod, fs; v₀=1500, ϵ₀=0.2, η₀=0.4, c
         ϵ = zeros(Float32,nz,ny,nx)
         η = zeros(Float32,nz,ny,nx)
     else
-        ϵ = Float32[]
-        η = Float32[]
+        ϵ = Array{Float32}(undef,0,0,0)
+        η = Array{Float32}(undef,0,0,0)
     end
     
     b = ones(Float32,nz,ny,nx)


### PR DESCRIPTION
This makes the array dimensions consistent in the make_op method regardless of the model-space.

@jkwashbourne this seems to fix some of the unit-test failures that we are experiencing on the `degrad` branch.