### PR TITLE
Fix `srcillum` model size errors, and add `srcillum` unit tests

### DIFF
--- a/test/jop_prop2DAcoIsoDenQ_DEO2_FDTD.jl
+++ b/test/jop_prop2DAcoIsoDenQ_DEO2_FDTD.jl
@@ -157,6 +157,14 @@ end
     close(F)
 end
 
+@testset "JopProp2DAcoIsoDenQ_DEO2_FDTD -- srcillum, C=$C, modeltype=$modeltype" for C in (Float32, UInt32), modeltype in modeltypes
+    m₀, F = make_op(:hicks, modeltype, false, comptype = C)
+    d₁ = F * m₀
+    s1 = srcillum(J)
+    close(F)
+end
+
+
 #=
 @testset "JopProp2DAcoIsoDenQ_DEO2_FDTD -- analytic, direct, interpmethod=$interpmethod" for interpmethod in (:hicks, :linear)
     z,x,dz,dx,dtrec,dtmod,t,sz,sx,c = 0.5,1.0,0.02,0.02,0.004,0.0004,1.0,0.25,0.02,1.5

--- a/test/jop_prop2DAcoIsoDenQ_DEO2_FDTD.jl
+++ b/test/jop_prop2DAcoIsoDenQ_DEO2_FDTD.jl
@@ -159,11 +159,14 @@ end
 
 @testset "JopProp2DAcoIsoDenQ_DEO2_FDTD -- srcillum, C=$C, modeltype=$modeltype" for C in (Float32, UInt32), modeltype in modeltypes
     m₀, F = make_op(:hicks, modeltype, false, comptype = C)
-    d₁ = F * m₀
-    s1 = srcillum(J)
+    d₁ = F * m₀;
+    J = jacobian(F, m₀);
+    s1 = srcillum(F, m₀);
+    s2 = srcillum(J);
     close(F)
+    @test s1 ≈ s2
+    @test maximum(s1) > 0
 end
-
 
 #=
 @testset "JopProp2DAcoIsoDenQ_DEO2_FDTD -- analytic, direct, interpmethod=$interpmethod" for interpmethod in (:hicks, :linear)

--- a/test/jop_prop2DAcoTTIDenQ_DEO2_FDTD.jl
+++ b/test/jop_prop2DAcoTTIDenQ_DEO2_FDTD.jl
@@ -153,6 +153,17 @@ end
     close(F)
 end
 
+@testset "JopProp2DAcoTTIDenQ_DEO2_FDTD -- srcillum, C=$C, modeltype=$modeltype" for C in (Float32, UInt32), modeltype in ("vϵη", "v")
+    m₀, F = make_op(:hicks, modeltype, false, comptype = C)
+    d₁ = F * m₀;
+    J = jacobian(F, m₀);
+    s1 = srcillum(F, m₀);
+    s2 = srcillum(J);
+    close(F)
+    @test s1 ≈ s2
+    @test maximum(s1) > 0
+end
+
 #=
 @testset "JopProp2DAcoTTIDenQ_DEO2_FDTD -- analytic, direct, for model type $modeltype, interpmethod=$interpmethod" for modeltype in ("vϵη","v"), interpmethod in (:linear,:hicks)
     z,x,dz,dx,dtrec,dtmod,t,sz,sx,c = 0.5,1.0,0.02,0.02,0.004,0.0004,1.0,0.25,0.02,1.5

--- a/test/jop_prop2DAcoVTIDenQ_DEO2_FDTD.jl
+++ b/test/jop_prop2DAcoVTIDenQ_DEO2_FDTD.jl
@@ -156,6 +156,17 @@ end
     close(F)
 end
 
+@testset "JopProp2DAcoVTIDenQ_DEO2_FDTD -- srcillum, C=$C, modeltype=$modeltype" for C in (Float32, UInt32), modeltype in ("vϵη", "v")
+    m₀, F = make_op(:hicks, modeltype, false, comptype = C)
+    d₁ = F * m₀;
+    J = jacobian(F, m₀);
+    s1 = srcillum(F, m₀);
+    s2 = srcillum(J);
+    close(F)
+    @test s1 ≈ s2
+    @test maximum(s1) > 0
+end
+
 #=
 @testset "JopProp2DAcoVTIDenQ_DEO2_FDTD -- analytic, direct, for model type $modeltype, interpmethod=$interpmethod" for modeltype in ("vϵη","v"), interpmethod in (:hicks,:linear)
     z,x,dz,dx,dtrec,dtmod,t,sz,sx,c = 0.5,1.0,0.02,0.02,0.004,0.0004,1.0,0.25,0.02,1.5

--- a/test/jop_prop3DAcoIsoDenQ_DEO2_FDTD.jl
+++ b/test/jop_prop3DAcoIsoDenQ_DEO2_FDTD.jl
@@ -161,6 +161,28 @@ end
     close(F)
 end
 
+@testset "JopProp3DAcoVTIDenQ_DEO2_FDTD -- srcillum, C=$C, modeltype=$modeltype" for C in (Float32, UInt32), modeltype in modeltypes
+    m₀, F = make_op(:hicks, modeltype, false, comptype = C)
+    d₁ = F * m₀;
+    J = jacobian(F, m₀);
+    s1 = srcillum(F, m₀);
+    s2 = srcillum(J);
+    close(F)
+    @test s1 ≈ s2
+    @test maximum(s1) > 0
+end
+
+@testset "JopProp3DAcoVTIDenQ_DEO2_FDTD -- srcillum, C=$C, modeltype=$modeltype" for C in (Float32, UInt32), modeltype in modeltypes
+    m₀, F = make_op(:hicks, modeltype, false, comptype = C)
+    d₁ = F * m₀;
+    J = jacobian(F, m₀);
+    s1 = srcillum(F, m₀);
+    s2 = srcillum(J);
+    close(F)
+    @test s1 ≈ s2
+    @test maximum(s1) > 0
+end
+
 #=
 @testset "JopProp3DAcoIsoDenQ_DEO2_FDTD -- analytic, direct, interpmethod=$interpmethod" for interpmethod in (:hicks,:linear)
     z,y,x,dz,dy,dx,dtrec,dtmod,tmax,sz,sy,sx,c = 2000.0,500.0,2500.0,40.0,40.0,40.0,0.016,0.004,2.0,1000.0,250.0,20.0,1500.0

--- a/test/jop_prop3DAcoIsoDenQ_DEO2_FDTD.jl
+++ b/test/jop_prop3DAcoIsoDenQ_DEO2_FDTD.jl
@@ -172,17 +172,6 @@ end
     @test maximum(s1) > 0
 end
 
-@testset "JopProp3DAcoVTIDenQ_DEO2_FDTD -- srcillum, C=$C, modeltype=$modeltype" for C in (Float32, UInt32), modeltype in modeltypes
-    m₀, F = make_op(:hicks, modeltype, false, comptype = C)
-    d₁ = F * m₀;
-    J = jacobian(F, m₀);
-    s1 = srcillum(F, m₀);
-    s2 = srcillum(J);
-    close(F)
-    @test s1 ≈ s2
-    @test maximum(s1) > 0
-end
-
 #=
 @testset "JopProp3DAcoIsoDenQ_DEO2_FDTD -- analytic, direct, interpmethod=$interpmethod" for interpmethod in (:hicks,:linear)
     z,y,x,dz,dy,dx,dtrec,dtmod,tmax,sz,sy,sx,c = 2000.0,500.0,2500.0,40.0,40.0,40.0,0.016,0.004,2.0,1000.0,250.0,20.0,1500.0

--- a/test/jop_prop3DAcoTTIDenQ_DEO2_FDTD.jl
+++ b/test/jop_prop3DAcoTTIDenQ_DEO2_FDTD.jl
@@ -148,7 +148,7 @@ end
 end
 
 # note the compression is exercised on the second pass of F * m₀
-@testset "JopProp2DAcoTTIDenQ_DEO2_FDTD -- serialization, modeltype=$modeltype, C=$C" for modeltype in ("vϵη", "v"), C in (Float32,UInt32)
+@testset "JopProp23AcoTTIDenQ_DEO2_FDTD -- serialization, modeltype=$modeltype, C=$C" for modeltype in ("vϵη", "v"), C in (Float32,UInt32)
     m₀, F = make_op(modeltype, :hicks, false, comptype = C) 
     d₁ = F * m₀
     d₂ = F * m₀
@@ -157,7 +157,7 @@ end
     close(F)
 end
 
-@testset "JopProp2DAcoTTIDenQ_DEO2_FDTD -- srcillum, C=$C, modeltype=$modeltype" for C in (Float32, UInt32), modeltype in ("vϵη", "v")
+@testset "JopProp3DAcoTTIDenQ_DEO2_FDTD -- srcillum, C=$C, modeltype=$modeltype" for C in (Float32, UInt32), modeltype in ("vϵη", "v")
     m₀, F = make_op(:hicks, modeltype, false, comptype = C)
     d₁ = F * m₀;
     J = jacobian(F, m₀);

--- a/test/jop_prop3DAcoTTIDenQ_DEO2_FDTD.jl
+++ b/test/jop_prop3DAcoTTIDenQ_DEO2_FDTD.jl
@@ -148,13 +148,24 @@ end
 end
 
 # note the compression is exercised on the second pass of F * m₀
-@testset "JopProp2DAcoVTIDenQ_DEO2_FDTD -- serialization, modeltype=$modeltype, C=$C" for modeltype in ("vϵη", "v"), C in (Float32,UInt32)
+@testset "JopProp2DAcoTTIDenQ_DEO2_FDTD -- serialization, modeltype=$modeltype, C=$C" for modeltype in ("vϵη", "v"), C in (Float32,UInt32)
     m₀, F = make_op(modeltype, :hicks, false, comptype = C) 
     d₁ = F * m₀
     d₂ = F * m₀
     @test d₁ ≈ d₂
 
     close(F)
+end
+
+@testset "JopProp2DAcoTTIDenQ_DEO2_FDTD -- srcillum, C=$C, modeltype=$modeltype" for C in (Float32, UInt32), modeltype in ("vϵη", "v")
+    m₀, F = make_op(:hicks, modeltype, false, comptype = C)
+    d₁ = F * m₀;
+    J = jacobian(F, m₀);
+    s1 = srcillum(F, m₀);
+    s2 = srcillum(J);
+    close(F)
+    @test s1 ≈ s2
+    @test maximum(s1) > 0
 end
 
 #=

--- a/test/jop_prop3DAcoTTIDenQ_DEO2_FDTD.jl
+++ b/test/jop_prop3DAcoTTIDenQ_DEO2_FDTD.jl
@@ -148,7 +148,7 @@ end
 end
 
 # note the compression is exercised on the second pass of F * m₀
-@testset "JopProp23AcoTTIDenQ_DEO2_FDTD -- serialization, modeltype=$modeltype, C=$C" for modeltype in ("vϵη", "v"), C in (Float32,UInt32)
+@testset "JopProp3DAcoTTIDenQ_DEO2_FDTD -- serialization, modeltype=$modeltype, C=$C" for modeltype in ("vϵη", "v"), C in (Float32,UInt32)
     m₀, F = make_op(modeltype, :hicks, false, comptype = C) 
     d₁ = F * m₀
     d₂ = F * m₀

--- a/test/jop_prop3DAcoVTIDenQ_DEO2_FDTD.jl
+++ b/test/jop_prop3DAcoVTIDenQ_DEO2_FDTD.jl
@@ -155,6 +155,17 @@ end
     close(F)
 end
 
+@testset "JopProp2DAcoVTIDenQ_DEO2_FDTD -- srcillum, C=$C, modeltype=$modeltype" for C in (Float32, UInt32), modeltype in ("vϵη", "v")
+    m₀, F = make_op(:hicks, modeltype, false, comptype = C)
+    d₁ = F * m₀;
+    J = jacobian(F, m₀);
+    s1 = srcillum(F, m₀);
+    s2 = srcillum(J);
+    close(F)
+    @test s1 ≈ s2
+    @test maximum(s1) > 0
+end
+
 #=
 @testset "JopProp3DAcoVTIDenQ_DEO2_FDTD -- analytic, direct, for model type $modeltype, interpmethod=$interpmethod" for modeltype in ("vϵη","v"), interpmethod in (:linear,:hicks)
     z,y,x,dz,dy,dx,dtrec,dtmod,tmax,sz,sy,sx,c = 2000.0,500.0,2500.0,40.0,40.0,40.0,0.016,0.004,2.0,1000.0,250.0,20.0,1500.0

--- a/test/jop_prop3DAcoVTIDenQ_DEO2_FDTD.jl
+++ b/test/jop_prop3DAcoVTIDenQ_DEO2_FDTD.jl
@@ -146,7 +146,7 @@ end
 end
 
 # note the compression is exercised on the second pass of F * m₀
-@testset "JopProp2DAcoVTIDenQ_DEO2_FDTD -- serialization, modeltype=$modeltype, C=$C" for modeltype in ("vϵη", "v"), C in (Float32,UInt32)
+@testset "JopProp3DAcoVTIDenQ_DEO2_FDTD -- serialization, modeltype=$modeltype, C=$C" for modeltype in ("vϵη", "v"), C in (Float32,UInt32)
     m₀, F = make_op(modeltype, :hicks, false, comptype = C) 
     d₁ = F * m₀
     d₂ = F * m₀
@@ -155,7 +155,7 @@ end
     close(F)
 end
 
-@testset "JopProp2DAcoVTIDenQ_DEO2_FDTD -- srcillum, C=$C, modeltype=$modeltype" for C in (Float32, UInt32), modeltype in ("vϵη", "v")
+@testset "JopProp3DAcoVTIDenQ_DEO2_FDTD -- srcillum, C=$C, modeltype=$modeltype" for C in (Float32, UInt32), modeltype in ("vϵη", "v")
     m₀, F = make_op(:hicks, modeltype, false, comptype = C)
     d₁ = F * m₀;
     J = jacobian(F, m₀);


### PR DESCRIPTION
After density capability for isotropic, model sizes are now one size larger than problem dimensionality for all physics (iso, vti, tti). This PR fixed the problem of assigning the correct array size for calls to `srcillum`, and adds unit tests for `srcillum` to all propagators. 

closes #8 
closes #34 