### PR TITLE
serialization tests for dtrec != dtmod

### DIFF
--- a/src/jop_prop2DAcoIsoDenQ_DEO2_FDTD.jl
+++ b/src/jop_prop2DAcoIsoDenQ_DEO2_FDTD.jl
@@ -560,6 +560,12 @@ function JopProp2DAcoIsoDenQ_DEO2_FDTD_f!(d::AbstractArray, m::AbstractArray{Flo
             WaveFD.compressedread!(iofield, kwargs[:compressor]["pold"], it, field)
             WaveFD.extractdata!(d, field, it, iz, ix, c)
         end
+
+        # interpolate to dtmod and back so amplitudes match data created by nonlinear forward operator
+        ntmod = WaveFD.default_ntmod(kwargs[:dtrec], kwargs[:dtmod], kwargs[:ntrec])
+        dinterp = zeros(Float32, ntmod, size(d, 2))
+        WaveFD.interpadjoint!(WaveFD.interpfilters(kwargs[:dtmod], kwargs[:dtrec], 1, WaveFD.LangC(), kwargs[:nthreads]), dinterp, d)
+        WaveFD.interpforward!(WaveFD.interpfilters(kwargs[:dtmod], kwargs[:dtrec], 0, WaveFD.LangC(), kwargs[:nthreads]), d, dinterp)
         close(iofield)
         close(kwargs[:compressor]["pold"])
     end

--- a/src/jop_prop2DAcoTTIDenQ_DEO2_FDTD.jl
+++ b/src/jop_prop2DAcoTTIDenQ_DEO2_FDTD.jl
@@ -599,6 +599,12 @@ function JopProp2DAcoTTIDenQ_DEO2_FDTD_f!(d::AbstractArray, m::AbstractArray{Flo
             WaveFD.compressedread!(iofield, kwargs[:compressor]["pold"], it, field)
             WaveFD.extractdata!(d, field, it, iz, ix, c)
         end
+
+        # interpolate to dtmod and back so amplitudes match data created by nonlinear forward operator
+        ntmod = WaveFD.default_ntmod(kwargs[:dtrec], kwargs[:dtmod], kwargs[:ntrec])
+        dinterp = zeros(Float32, ntmod, size(d, 2))
+        WaveFD.interpadjoint!(WaveFD.interpfilters(kwargs[:dtmod], kwargs[:dtrec], 1, WaveFD.LangC(), kwargs[:nthreads]), dinterp, d)
+        WaveFD.interpforward!(WaveFD.interpfilters(kwargs[:dtmod], kwargs[:dtrec], 0, WaveFD.LangC(), kwargs[:nthreads]), d, dinterp)
         close(iofield)
         close(kwargs[:compressor]["pold"])
     end

--- a/src/jop_prop2DAcoVTIDenQ_DEO2_FDTD.jl
+++ b/src/jop_prop2DAcoVTIDenQ_DEO2_FDTD.jl
@@ -598,6 +598,12 @@ function JopProp2DAcoVTIDenQ_DEO2_FDTD_f!(d::AbstractArray, m::AbstractArray{Flo
             WaveFD.compressedread!(iofield, kwargs[:compressor]["pold"], it, field)
             WaveFD.extractdata!(d, field, it, iz, ix, c)
         end
+
+        # interpolate to dtmod and back so amplitudes match data created by nonlinear forward operator
+        ntmod = WaveFD.default_ntmod(kwargs[:dtrec], kwargs[:dtmod], kwargs[:ntrec])
+        dinterp = zeros(Float32, ntmod, size(d, 2))
+        WaveFD.interpadjoint!(WaveFD.interpfilters(kwargs[:dtmod], kwargs[:dtrec], 1, WaveFD.LangC(), kwargs[:nthreads]), dinterp, d)
+        WaveFD.interpforward!(WaveFD.interpfilters(kwargs[:dtmod], kwargs[:dtrec], 0, WaveFD.LangC(), kwargs[:nthreads]), d, dinterp)
         close(iofield)
         close(kwargs[:compressor]["pold"])
     end

--- a/src/jop_prop3DAcoIsoDenQ_DEO2_FDTD.jl
+++ b/src/jop_prop3DAcoIsoDenQ_DEO2_FDTD.jl
@@ -587,6 +587,12 @@ function JopProp3DAcoIsoDenQ_DEO2_FDTD_f!(d::AbstractArray, m::AbstractArray{Flo
             WaveFD.compressedread!(iofield, kwargs[:compressor]["pold"], it, field)
             WaveFD.extractdata!(d, field, it, iz, iy, ix, c)
         end
+
+        # interpolate to dtmod and back so amplitudes match data created by nonlinear forward operator
+        ntmod = WaveFD.default_ntmod(kwargs[:dtrec], kwargs[:dtmod], kwargs[:ntrec])
+        dinterp = zeros(Float32, ntmod, size(d, 2))
+        WaveFD.interpadjoint!(WaveFD.interpfilters(kwargs[:dtmod], kwargs[:dtrec], 1, WaveFD.LangC(), kwargs[:nthreads]), dinterp, d)
+        WaveFD.interpforward!(WaveFD.interpfilters(kwargs[:dtmod], kwargs[:dtrec], 0, WaveFD.LangC(), kwargs[:nthreads]), d, dinterp)
         close(iofield)
         close(kwargs[:compressor]["pold"])
     end

--- a/src/jop_prop3DAcoTTIDenQ_DEO2_FDTD.jl
+++ b/src/jop_prop3DAcoTTIDenQ_DEO2_FDTD.jl
@@ -639,6 +639,12 @@ function JopProp3DAcoTTIDenQ_DEO2_FDTD_f!(d::AbstractArray, m::AbstractArray{Flo
             WaveFD.compressedread!(iofield, kwargs[:compressor]["pold"], it, field)
             WaveFD.extractdata!(d, field, it, iz, iy, ix, c)
         end
+
+        # interpolate to dtmod and back so amplitudes match data created by nonlinear forward operator
+        ntmod = WaveFD.default_ntmod(kwargs[:dtrec], kwargs[:dtmod], kwargs[:ntrec])
+        dinterp = zeros(Float32, ntmod, size(d, 2))
+        WaveFD.interpadjoint!(WaveFD.interpfilters(kwargs[:dtmod], kwargs[:dtrec], 1, WaveFD.LangC(), kwargs[:nthreads]), dinterp, d)
+        WaveFD.interpforward!(WaveFD.interpfilters(kwargs[:dtmod], kwargs[:dtrec], 0, WaveFD.LangC(), kwargs[:nthreads]), d, dinterp)
         close(iofield)
         close(kwargs[:compressor]["pold"])
     end

--- a/src/jop_prop3DAcoVTIDenQ_DEO2_FDTD.jl
+++ b/src/jop_prop3DAcoVTIDenQ_DEO2_FDTD.jl
@@ -624,6 +624,12 @@ function JopProp3DAcoVTIDenQ_DEO2_FDTD_f!(d::AbstractArray, m::AbstractArray{Flo
             WaveFD.compressedread!(iofield, kwargs[:compressor]["pold"], it, field)
             WaveFD.extractdata!(d, field, it, iz, iy, ix, c)
         end
+
+        # interpolate to dtmod and back so amplitudes match data created by nonlinear forward operator
+        ntmod = WaveFD.default_ntmod(kwargs[:dtrec], kwargs[:dtmod], kwargs[:ntrec])
+        dinterp = zeros(Float32, ntmod, size(d, 2))
+        WaveFD.interpadjoint!(WaveFD.interpfilters(kwargs[:dtmod], kwargs[:dtrec], 1, WaveFD.LangC(), kwargs[:nthreads]), dinterp, d)
+        WaveFD.interpforward!(WaveFD.interpfilters(kwargs[:dtmod], kwargs[:dtrec], 0, WaveFD.LangC(), kwargs[:nthreads]), d, dinterp)
         close(iofield)
         close(kwargs[:compressor]["pold"])
     end

--- a/test/jop_prop2DAcoIsoDenQ_DEO2_FDTD.jl
+++ b/test/jop_prop2DAcoIsoDenQ_DEO2_FDTD.jl
@@ -173,10 +173,11 @@ end
 
 # note the compression is exercised on the second pass of F * m₀
 @testset "JopProp2DAcoIsoDenQ_DEO2_FDTD -- serialization, C=$C, modeltype=$modeltype" for C in (Float32, UInt32), modeltype in modeltypes
-    m₀, F = make_op(:hicks, modeltype, false, comptype = C, rec2mod=1)
+    m₀, F = make_op(:hicks, modeltype, false, comptype = C)
     d₁ = F * m₀
     d₂ = F * m₀
-    @test d₁ ≈ d₂
+    err = sum((d₁-d₂).^2)/sum(d₁.^2 .+ d₂.^2)*2
+    @test err < 1e-4
 
     close(F)
 end

--- a/test/jop_prop2DAcoTTIDenQ_DEO2_FDTD.jl
+++ b/test/jop_prop2DAcoTTIDenQ_DEO2_FDTD.jl
@@ -167,10 +167,11 @@ end
 
 # note the compression is exercised on the second pass of F * m₀
 @testset "JopProp2DAcoTTIDenQ_DEO2_FDTD -- serialization, modeltype=$modeltype, C=$C" for modeltype in ("vϵη", "v"), C in (Float32,UInt32)
-    m₀, F = make_op(modeltype, :hicks, false, comptype = C, rec2mod=1) 
+    m₀, F = make_op(modeltype, :hicks, false, comptype = C) 
     d₁ = F * m₀
     d₂ = F * m₀
-    @test d₁ ≈ d₂
+    err = sum((d₁-d₂).^2)/sum(d₁.^2 .+ d₂.^2)*2
+    @test err < 1e-4
 
     close(F)
 end

--- a/test/jop_prop2DAcoVTIDenQ_DEO2_FDTD.jl
+++ b/test/jop_prop2DAcoVTIDenQ_DEO2_FDTD.jl
@@ -169,10 +169,11 @@ end
 
 # note the compression is exercised on the second pass of F * m₀
 @testset "JopProp2DAcoVTIDenQ_DEO2_FDTD -- serialization, modeltype=$modeltype, C=$C" for modeltype in ("vϵη", "v"), C in (Float32,UInt32)
-    m₀, F = make_op(modeltype, :hicks, false, comptype = C, rec2mod=1) 
+    m₀, F = make_op(modeltype, :hicks, false, comptype = C) 
     d₁ = F * m₀
     d₂ = F * m₀
-    @test d₁ ≈ d₂
+    err = sum((d₁-d₂).^2)/sum(d₁.^2 .+ d₂.^2)*2
+    @test err < 1e-4
 
     close(F)
 end

--- a/test/jop_prop3DAcoIsoDenQ_DEO2_FDTD.jl
+++ b/test/jop_prop3DAcoIsoDenQ_DEO2_FDTD.jl
@@ -179,10 +179,11 @@ end
 
 # note the compression is exercised on the second pass of F * m₀
 @testset "JopProp3DAcoVTIDenQ_DEO2_FDTD -- serialization, modeltype=$modeltype, C=$C" for C in (Float32, UInt32), modeltype in modeltypes
-    m₀, F = make_op(:linear, modeltype, false, comptype = C, rec2mod=1)
+    m₀, F = make_op(:linear, modeltype, false, comptype = C)
     d₁ = F * m₀
     d₂ = F * m₀
-    @test d₁ ≈ d₂
+    err = sum((d₁-d₂).^2)/sum(d₁.^2 .+ d₂.^2)*2
+    @test err < 1e-4
 
     close(F)
 end

--- a/test/jop_prop3DAcoTTIDenQ_DEO2_FDTD.jl
+++ b/test/jop_prop3DAcoTTIDenQ_DEO2_FDTD.jl
@@ -173,10 +173,11 @@ end
 
 # note the compression is exercised on the second pass of F * m₀
 @testset "JopProp3DAcoTTIDenQ_DEO2_FDTD -- serialization, modeltype=$modeltype, C=$C" for modeltype in ("vϵη", "v"), C in (Float32,UInt32)
-    m₀, F = make_op(modeltype, :hicks, false, comptype = C, rec2mod=1) 
+    m₀, F = make_op(modeltype, :hicks, false, comptype = C) 
     d₁ = F * m₀
     d₂ = F * m₀
-    @test d₁ ≈ d₂
+    err = sum((d₁-d₂).^2)/sum(d₁.^2 .+ d₂.^2)*2
+    @test err < 1e-4
 
     close(F)
 end

--- a/test/jop_prop3DAcoVTIDenQ_DEO2_FDTD.jl
+++ b/test/jop_prop3DAcoVTIDenQ_DEO2_FDTD.jl
@@ -171,10 +171,11 @@ end
 
 # note the compression is exercised on the second pass of F * m₀
 @testset "JopProp3DAcoVTIDenQ_DEO2_FDTD -- serialization, modeltype=$modeltype, C=$C" for modeltype in ("vϵη", "v"), C in (Float32,UInt32)
-    m₀, F = make_op(modeltype, :hicks, false, comptype = C, rec2mod=1) 
+    m₀, F = make_op(modeltype, :hicks, false, comptype = C) 
     d₁ = F * m₀
     d₂ = F * m₀
-    @test d₁ ≈ d₂
+    err = sum((d₁-d₂).^2)/sum(d₁.^2 .+ d₂.^2)*2
+    @test err < 1e-4
 
     close(F)
 end


### PR DESCRIPTION
perform forward and adj interpolation on deserialized data so the data match snapshotted fwd modeling for dtrec != dtmod
note that changing the interpolator in the future may allow for better rtol values in the serialization tests.